### PR TITLE
Add Flutter app architecture skeleton

### DIFF
--- a/klubradio_archivum/lib/main.dart
+++ b/klubradio_archivum/lib/main.dart
@@ -1,122 +1,169 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'providers/episode_provider.dart';
+import 'providers/podcast_provider.dart';
+import 'providers/theme_provider.dart';
+import 'screens/about_screen/about_screen.dart';
+import 'screens/discover_screen/discover_screen.dart';
+import 'screens/download_manager_screen/download_manager_screen.dart';
+import 'screens/home_screen/home_screen.dart';
+import 'screens/now_playing_screen/now_playing_screen.dart';
+import 'screens/podcast_detail_screen/podcast_detail_screen.dart';
+import 'screens/profile_screen/profile_screen.dart';
+import 'screens/search_screen/search_screen.dart';
+import 'screens/settings_screen/settings_screen.dart';
+import 'screens/widgets/stateful/now_playing_bar.dart';
+import 'screens/widgets/stateless/app_bottom_navigation_bar.dart';
+import 'services/api_service.dart';
+import 'services/audio_player_service.dart';
+import 'services/download_service.dart';
 
 void main() {
-  runApp(const MyApp());
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const KlubradioArchivumApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class KlubradioArchivumApp extends StatefulWidget {
+  const KlubradioArchivumApp({super.key});
 
-  // This widget is the root of your application.
+  @override
+  State<KlubradioArchivumApp> createState() => _KlubradioArchivumAppState();
+}
+
+class _KlubradioArchivumAppState extends State<KlubradioArchivumApp> {
+  late final ApiService _apiService;
+  late final AudioPlayerService _audioPlayerService;
+  late final DownloadService _downloadService;
+
+  @override
+  void initState() {
+    super.initState();
+    _apiService = ApiService();
+    _audioPlayerService = AudioPlayerService();
+    _downloadService = DownloadService();
+  }
+
+  @override
+  void dispose() {
+    _audioPlayerService.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+    return MultiProvider(
+      providers: [
+        Provider<ApiService>.value(value: _apiService),
+        Provider<AudioPlayerService>.value(value: _audioPlayerService),
+        Provider<DownloadService>.value(value: _downloadService),
+        ChangeNotifierProvider<ThemeProvider>(
+          create: (_) => ThemeProvider(),
+        ),
+        ChangeNotifierProxyProvider<ApiService, PodcastProvider>(
+          create: (context) => PodcastProvider(apiService: _apiService),
+          update: (context, apiService, previous) =>
+              (previous ?? PodcastProvider(apiService: apiService))
+                ..updateApiService(apiService),
+        ),
+        ChangeNotifierProxyProvider3<ApiService, AudioPlayerService,
+            DownloadService, EpisodeProvider>(
+          create: (context) => EpisodeProvider(
+            apiService: _apiService,
+            audioPlayerService: _audioPlayerService,
+            downloadService: _downloadService,
+          ),
+          update:
+              (context, apiService, audioPlayerService, downloadService, previous) =>
+                  (previous ??
+                          EpisodeProvider(
+                            apiService: apiService,
+                            audioPlayerService: audioPlayerService,
+                            downloadService: downloadService,
+                          ))
+                    ..updateDependencies(
+                      apiService: apiService,
+                      audioPlayerService: audioPlayerService,
+                      downloadService: downloadService,
+                    ),
+        ),
+      ],
+      child: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, _) {
+          return MaterialApp(
+            title: 'Klubrádió Archívum',
+            debugShowCheckedModeBanner: false,
+            themeMode: themeProvider.themeMode,
+            theme: themeProvider.lightTheme,
+            darkTheme: themeProvider.darkTheme,
+            routes: {
+              AboutScreen.routeName: (_) => const AboutScreen(),
+              SearchScreen.routeName: (_) => const SearchScreen(),
+              NowPlayingScreen.routeName: (_) => const NowPlayingScreen(),
+              SettingsScreen.routeName: (_) => const SettingsScreen(),
+            },
+            onGenerateRoute: (settings) {
+              if (settings.name == PodcastDetailScreen.routeName &&
+                  settings.arguments is PodcastDetailArguments) {
+                final args = settings.arguments! as PodcastDetailArguments;
+                return MaterialPageRoute<void>(
+                  builder: (_) => PodcastDetailScreen(podcast: args.podcast),
+                );
+              }
+              return null;
+            },
+            home: const _RootNavigationScaffold(),
+          );
+        },
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+class _RootNavigationScaffold extends StatefulWidget {
+  const _RootNavigationScaffold();
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<_RootNavigationScaffold> createState() => _RootNavigationScaffoldState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+class _RootNavigationScaffoldState extends State<_RootNavigationScaffold> {
+  int _currentIndex = 0;
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+  final List<Widget> _screens = const <Widget>[
+    HomeScreen(),
+    DiscoverScreen(),
+    DownloadManagerScreen(),
+    ProfileScreen(),
+    SettingsScreen(),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      context.read<PodcastProvider>().loadHomeContent();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+      body: Column(
+        children: [
+          Expanded(
+            child: IndexedStack(
+              index: _currentIndex,
+              children: _screens,
             ),
-          ],
-        ),
+          ),
+          const NowPlayingBar(),
+        ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add_rounded),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      bottomNavigationBar: AppBottomNavigationBar(
+        currentIndex: _currentIndex,
+        onTap: (index) => setState(() => _currentIndex = index),
+      ),
     );
   }
 }

--- a/klubradio_archivum/lib/models/episode.dart
+++ b/klubradio_archivum/lib/models/episode.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+
+class Episode {
+  const Episode({
+    required this.id,
+    required this.podcastId,
+    required this.title,
+    required this.description,
+    required this.audioUrl,
+    required this.duration,
+    required this.publishedAt,
+    this.imageUrl = '',
+    this.isDownloaded = false,
+    this.localFilePath,
+    this.playbackPosition = Duration.zero,
+  });
+
+  final String id;
+  final String podcastId;
+  final String title;
+  final String description;
+  final String audioUrl;
+  final Duration duration;
+  final DateTime publishedAt;
+  final String imageUrl;
+  final bool isDownloaded;
+  final String? localFilePath;
+  final Duration playbackPosition;
+
+  Episode copyWith({
+    String? id,
+    String? podcastId,
+    String? title,
+    String? description,
+    String? audioUrl,
+    Duration? duration,
+    DateTime? publishedAt,
+    String? imageUrl,
+    bool? isDownloaded,
+    String? localFilePath,
+    Duration? playbackPosition,
+  }) {
+    return Episode(
+      id: id ?? this.id,
+      podcastId: podcastId ?? this.podcastId,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      audioUrl: audioUrl ?? this.audioUrl,
+      duration: duration ?? this.duration,
+      publishedAt: publishedAt ?? this.publishedAt,
+      imageUrl: imageUrl ?? this.imageUrl,
+      isDownloaded: isDownloaded ?? this.isDownloaded,
+      localFilePath: localFilePath ?? this.localFilePath,
+      playbackPosition: playbackPosition ?? this.playbackPosition,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'podcast_id': podcastId,
+      'title': title,
+      'description': description,
+      'audio_url': audioUrl,
+      'duration_seconds': duration.inSeconds,
+      'published_at': publishedAt.toIso8601String(),
+      'image_url': imageUrl,
+      'is_downloaded': isDownloaded,
+      'local_file_path': localFilePath,
+      'playback_position_seconds': playbackPosition.inSeconds,
+    };
+  }
+
+  factory Episode.fromJson(Map<String, dynamic> json) {
+    final durationValue = json['duration_seconds'];
+    final playbackValue = json['playback_position_seconds'];
+
+    return Episode(
+      id: json['id']?.toString() ?? '',
+      podcastId: json['podcast_id']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      description: json['description']?.toString() ?? '',
+      audioUrl: json['audio_url']?.toString() ?? '',
+      duration: _parseDuration(durationValue),
+      publishedAt: _parseDate(json['published_at']),
+      imageUrl: json['image_url']?.toString() ?? '',
+      isDownloaded: json['is_downloaded'] == true,
+      localFilePath: json['local_file_path']?.toString(),
+      playbackPosition: _parseDuration(playbackValue),
+    );
+  }
+
+  static Duration _parseDuration(dynamic value) {
+    if (value == null) {
+      return Duration.zero;
+    }
+
+    if (value is int) {
+      return Duration(seconds: value);
+    }
+
+    if (value is double) {
+      return Duration(milliseconds: (value * 1000).round());
+    }
+
+    if (value is String && value.isNotEmpty) {
+      final parsed = int.tryParse(value);
+      if (parsed != null) {
+        return Duration(seconds: parsed);
+      }
+      final components = value.split(':');
+      if (components.length == 3) {
+        final hours = int.tryParse(components[0]) ?? 0;
+        final minutes = int.tryParse(components[1]) ?? 0;
+        final seconds = int.tryParse(components[2]) ?? 0;
+        return Duration(hours: hours, minutes: minutes, seconds: seconds);
+      }
+    }
+
+    return Duration.zero;
+  }
+
+  static DateTime _parseDate(dynamic value) {
+    if (value == null) {
+      return DateTime.fromMillisecondsSinceEpoch(0, isUtc: true).toLocal();
+    }
+
+    if (value is DateTime) {
+      return value.toLocal();
+    }
+
+    if (value is int) {
+      return DateTime.fromMillisecondsSinceEpoch(value * 1000, isUtc: true)
+          .toLocal();
+    }
+
+    if (value is String && value.isNotEmpty) {
+      return DateTime.tryParse(value)?.toLocal() ?? DateTime.now();
+    }
+
+    return DateTime.now();
+  }
+
+  static List<Episode> decodeList(String source) {
+    final List<dynamic> rawList = jsonDecode(source) as List<dynamic>;
+    return rawList
+        .whereType<Map<String, dynamic>>()
+        .map(Episode.fromJson)
+        .toList();
+  }
+
+  static String encodeList(List<Episode> episodes) {
+    return jsonEncode(episodes.map((episode) => episode.toJson()).toList());
+  }
+}

--- a/klubradio_archivum/lib/models/podcast.dart
+++ b/klubradio_archivum/lib/models/podcast.dart
@@ -1,0 +1,105 @@
+import 'episode.dart';
+import 'show_host.dart';
+
+class Podcast {
+  const Podcast({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.category,
+    required this.coverImageUrl,
+    required this.language,
+    this.hosts = const <ShowHost>[],
+    this.episodes = const <Episode>[],
+    this.episodeCount = 0,
+    this.isSubscribed = false,
+    this.storageRssPath,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final String category;
+  final String coverImageUrl;
+  final String language;
+  final List<ShowHost> hosts;
+  final List<Episode> episodes;
+  final int episodeCount;
+  final bool isSubscribed;
+  final String? storageRssPath;
+
+  Podcast copyWith({
+    String? id,
+    String? title,
+    String? description,
+    String? category,
+    String? coverImageUrl,
+    String? language,
+    List<ShowHost>? hosts,
+    List<Episode>? episodes,
+    int? episodeCount,
+    bool? isSubscribed,
+    String? storageRssPath,
+  }) {
+    return Podcast(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      category: category ?? this.category,
+      coverImageUrl: coverImageUrl ?? this.coverImageUrl,
+      language: language ?? this.language,
+      hosts: hosts ?? this.hosts,
+      episodes: episodes ?? this.episodes,
+      episodeCount: episodeCount ?? this.episodeCount,
+      isSubscribed: isSubscribed ?? this.isSubscribed,
+      storageRssPath: storageRssPath ?? this.storageRssPath,
+    );
+  }
+
+  factory Podcast.fromJson(Map<String, dynamic> json) {
+    final hosts = (json['hosts'] as List<dynamic>?)
+            ?.whereType<Map<String, dynamic>>()
+            .map(ShowHost.fromJson)
+            .toList() ??
+        const <ShowHost>[];
+
+    final episodes = (json['episodes'] as List<dynamic>?)
+            ?.whereType<Map<String, dynamic>>()
+            .map(Episode.fromJson)
+            .toList() ??
+        const <Episode>[];
+
+    return Podcast(
+      id: json['id']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      description: json['description']?.toString() ?? '',
+      category: json['category']?.toString() ?? 'Egyéb',
+      coverImageUrl: json['cover_image_url']?.toString() ?? '',
+      language: json['language']?.toString() ?? 'hu',
+      hosts: hosts,
+      episodes: episodes,
+      episodeCount: json['episode_count'] is int
+          ? json['episode_count'] as int
+          : int.tryParse(json['episode_count']?.toString() ?? '') ??
+              episodes.length,
+      isSubscribed: json['is_subscribed'] == true,
+      storageRssPath: json['storage_rss_path']?.toString(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'title': title,
+      'description': description,
+      'category': category,
+      'cover_image_url': coverImageUrl,
+      'language': language,
+      'hosts': hosts.map((host) => host.toJson()).toList(),
+      'episodes': episodes.map((episode) => episode.toJson()).toList(),
+      'episode_count': episodeCount,
+      'is_subscribed': isSubscribed,
+      'storage_rss_path': storageRssPath,
+    };
+  }
+}

--- a/klubradio_archivum/lib/models/show_host.dart
+++ b/klubradio_archivum/lib/models/show_host.dart
@@ -1,0 +1,54 @@
+class ShowHost {
+  const ShowHost({
+    required this.id,
+    required this.name,
+    this.bio = '',
+    this.avatarUrl = '',
+    this.socialLinks = const <String>[],
+  });
+
+  final String id;
+  final String name;
+  final String bio;
+  final String avatarUrl;
+  final List<String> socialLinks;
+
+  ShowHost copyWith({
+    String? id,
+    String? name,
+    String? bio,
+    String? avatarUrl,
+    List<String>? socialLinks,
+  }) {
+    return ShowHost(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bio: bio ?? this.bio,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      socialLinks: socialLinks ?? this.socialLinks,
+    );
+  }
+
+  factory ShowHost.fromJson(Map<String, dynamic> json) {
+    return ShowHost(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      bio: json['bio']?.toString() ?? '',
+      avatarUrl: json['avatar_url']?.toString() ?? '',
+      socialLinks: (json['social_links'] as List<dynamic>?)
+              ?.map((link) => link.toString())
+              .toList() ??
+          const <String>[],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'name': name,
+      'bio': bio,
+      'avatar_url': avatarUrl,
+      'social_links': socialLinks,
+    };
+  }
+}

--- a/klubradio_archivum/lib/models/user_profile.dart
+++ b/klubradio_archivum/lib/models/user_profile.dart
@@ -1,0 +1,94 @@
+class UserProfile {
+  const UserProfile({
+    required this.id,
+    required this.displayName,
+    required this.email,
+    this.avatarUrl = '',
+    this.subscribedPodcastIds = const <String>[],
+    this.downloadedEpisodeIds = const <String>[],
+    this.recentlyPlayedEpisodeIds = const <String>[],
+    this.maxAutoDownloadEpisodes = 5,
+    this.notificationsEnabled = false,
+  });
+
+  final String id;
+  final String displayName;
+  final String email;
+  final String avatarUrl;
+  final List<String> subscribedPodcastIds;
+  final List<String> downloadedEpisodeIds;
+  final List<String> recentlyPlayedEpisodeIds;
+  final int maxAutoDownloadEpisodes;
+  final bool notificationsEnabled;
+
+  UserProfile copyWith({
+    String? id,
+    String? displayName,
+    String? email,
+    String? avatarUrl,
+    List<String>? subscribedPodcastIds,
+    List<String>? downloadedEpisodeIds,
+    List<String>? recentlyPlayedEpisodeIds,
+    int? maxAutoDownloadEpisodes,
+    bool? notificationsEnabled,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      email: email ?? this.email,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      subscribedPodcastIds:
+          subscribedPodcastIds ?? this.subscribedPodcastIds,
+      downloadedEpisodeIds:
+          downloadedEpisodeIds ?? this.downloadedEpisodeIds,
+      recentlyPlayedEpisodeIds:
+          recentlyPlayedEpisodeIds ?? this.recentlyPlayedEpisodeIds,
+      maxAutoDownloadEpisodes:
+          maxAutoDownloadEpisodes ?? this.maxAutoDownloadEpisodes,
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+    );
+  }
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      id: json['id']?.toString() ?? '',
+      displayName: json['display_name']?.toString() ?? '',
+      email: json['email']?.toString() ?? '',
+      avatarUrl: json['avatar_url']?.toString() ?? '',
+      subscribedPodcastIds: (json['subscribed_podcast_ids'] as List<dynamic>?)
+              ?.map((value) => value.toString())
+              .toList() ??
+          const <String>[],
+      downloadedEpisodeIds: (json['downloaded_episode_ids'] as List<dynamic>?)
+              ?.map((value) => value.toString())
+              .toList() ??
+          const <String>[],
+      recentlyPlayedEpisodeIds:
+          (json['recently_played_episode_ids'] as List<dynamic>?)
+                  ?.map((value) => value.toString())
+                  .toList() ??
+              const <String>[],
+      maxAutoDownloadEpisodes:
+          json['max_auto_download_episodes'] is int
+              ? json['max_auto_download_episodes'] as int
+              : int.tryParse(
+                      json['max_auto_download_episodes']?.toString() ?? '') ??
+                  5,
+      notificationsEnabled: json['notifications_enabled'] == true,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'display_name': displayName,
+      'email': email,
+      'avatar_url': avatarUrl,
+      'subscribed_podcast_ids': subscribedPodcastIds,
+      'downloaded_episode_ids': downloadedEpisodeIds,
+      'recently_played_episode_ids': recentlyPlayedEpisodeIds,
+      'max_auto_download_episodes': maxAutoDownloadEpisodes,
+      'notifications_enabled': notificationsEnabled,
+    };
+  }
+}

--- a/klubradio_archivum/lib/providers/episode_provider.dart
+++ b/klubradio_archivum/lib/providers/episode_provider.dart
@@ -1,0 +1,336 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+
+import '../models/episode.dart';
+import '../services/api_service.dart';
+import '../services/audio_player_service.dart';
+import '../services/download_service.dart';
+
+class EpisodeProvider extends ChangeNotifier {
+  EpisodeProvider({
+    required ApiService apiService,
+    required AudioPlayerService audioPlayerService,
+    required DownloadService downloadService,
+  })  : _apiService = apiService,
+        _audioPlayerService = audioPlayerService,
+        _downloadService = downloadService {
+    _playerStateSubscription =
+        _audioPlayerService.playerStateStream.listen(_onPlayerStateChanged);
+    _positionSubscription =
+        _audioPlayerService.positionStream.listen(_onPositionChanged);
+  }
+
+  ApiService _apiService;
+  AudioPlayerService _audioPlayerService;
+  DownloadService _downloadService;
+
+  late StreamSubscription<PlayerState> _playerStateSubscription;
+  StreamSubscription<Duration>? _positionSubscription;
+
+  final Map<String, List<Episode>> _episodesByPodcast =
+      <String, List<Episode>>{};
+  final List<Episode> _recentlyPlayed = <Episode>[];
+  final List<Episode> _downloadedEpisodes = <Episode>[];
+  final Map<String, double> _downloadProgress = <String, double>{};
+  final List<Episode> _searchResults = <Episode>[];
+  final List<String> _recentSearches = <String>[];
+
+  Episode? _nowPlaying;
+  bool _isLoading = false;
+  bool _isSearching = false;
+  bool _isPlaying = false;
+  String? _errorMessage;
+  Duration _currentPosition = Duration.zero;
+  int _maxAutoDownloadEpisodes = 5;
+
+  bool get isLoading => _isLoading;
+  bool get isSearching => _isSearching;
+  bool get isPlaying => _isPlaying;
+  String? get errorMessage => _errorMessage;
+  Duration get currentPosition => _currentPosition;
+  Episode? get nowPlaying => _nowPlaying;
+  int get maxAutoDownloadEpisodes => _maxAutoDownloadEpisodes;
+
+  List<Episode> episodesForPodcast(String podcastId) =>
+      List<Episode>.unmodifiable(_episodesByPodcast[podcastId] ??
+          const <Episode>[]);
+
+  List<Episode> get recentlyPlayed =>
+      List<Episode>.unmodifiable(_recentlyPlayed);
+
+  List<Episode> get downloadedEpisodes =>
+      List<Episode>.unmodifiable(_downloadedEpisodes);
+
+  Map<String, double> get downloadProgress =>
+      Map<String, double>.unmodifiable(_downloadProgress);
+
+  List<Episode> get searchResults =>
+      List<Episode>.unmodifiable(_searchResults);
+
+  List<String> get recentSearches =>
+      List<String>.unmodifiable(_recentSearches);
+
+  void updateDependencies({
+    required ApiService apiService,
+    required AudioPlayerService audioPlayerService,
+    required DownloadService downloadService,
+  }) {
+    if (!identical(_audioPlayerService, audioPlayerService)) {
+      _playerStateSubscription.cancel();
+      _positionSubscription?.cancel();
+      _audioPlayerService = audioPlayerService;
+      _playerStateSubscription =
+          _audioPlayerService.playerStateStream.listen(_onPlayerStateChanged);
+      _positionSubscription =
+          _audioPlayerService.positionStream.listen(_onPositionChanged);
+    }
+
+    _apiService = apiService;
+    _downloadService = downloadService;
+  }
+
+  Future<void> loadEpisodesForPodcast(String podcastId) async {
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final episodes = await _apiService.fetchEpisodesForPodcast(podcastId);
+      _episodesByPodcast[podcastId] = episodes.map(_mergeDownloadState).toList();
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> playEpisode(Episode episode) async {
+    await _audioPlayerService.playEpisode(episode);
+    _nowPlaying = episode;
+    _isPlaying = true;
+    _addToRecentlyPlayed(episode);
+    notifyListeners();
+  }
+
+  Future<void> togglePlayPause() async {
+    if (_nowPlaying == null) {
+      return;
+    }
+
+    if (_isPlaying) {
+      await _audioPlayerService.pause();
+      _isPlaying = false;
+    } else {
+      await _audioPlayerService.play();
+      _isPlaying = true;
+    }
+    notifyListeners();
+  }
+
+  Future<void> pause() async {
+    if (!_isPlaying) {
+      return;
+    }
+    await _audioPlayerService.pause();
+    _isPlaying = false;
+    notifyListeners();
+  }
+
+  Future<void> resume() async {
+    if (_isPlaying || _nowPlaying == null) {
+      return;
+    }
+    await _audioPlayerService.play();
+    _isPlaying = true;
+    notifyListeners();
+  }
+
+  Future<void> seek(Duration position) async {
+    await _audioPlayerService.seek(position);
+  }
+
+  Future<void> stop() async {
+    await _audioPlayerService.stop();
+    _isPlaying = false;
+    _currentPosition = Duration.zero;
+    notifyListeners();
+  }
+
+  Future<void> downloadEpisode(Episode episode) async {
+    _downloadProgress[episode.id] = 0;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final filePath = await _downloadService.downloadEpisode(
+        episode,
+        onProgress: (received, total) {
+          if (total > 0) {
+            _downloadProgress[episode.id] = received / total;
+            notifyListeners();
+          }
+        },
+      );
+
+      final updatedEpisode = episode.copyWith(
+        isDownloaded: true,
+        localFilePath: filePath,
+      );
+
+      _downloadedEpisodes
+        ..removeWhere((item) => item.id == episode.id)
+        ..insert(0, updatedEpisode);
+
+      _replaceEpisodeInCollections(updatedEpisode);
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _downloadProgress.remove(episode.id);
+      notifyListeners();
+    }
+  }
+
+  Future<void> removeDownload(Episode episode) async {
+    if (episode.localFilePath == null) {
+      return;
+    }
+
+    await _downloadService.deleteDownloadedFile(episode.localFilePath!);
+    _downloadedEpisodes.removeWhere((item) => item.id == episode.id);
+    final updatedEpisode = episode.copyWith(
+      isDownloaded: false,
+      localFilePath: null,
+    );
+    _replaceEpisodeInCollections(updatedEpisode);
+    notifyListeners();
+  }
+
+  Future<void> searchEpisodes(String query) async {
+    final trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      _searchResults.clear();
+      _isSearching = false;
+      notifyListeners();
+      return;
+    }
+
+    _isSearching = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final results = await _apiService.searchEpisodes(trimmed);
+      _searchResults
+        ..clear()
+        ..addAll(results.map(_mergeDownloadState));
+      _recentSearches.remove(trimmed);
+      _recentSearches.insert(0, trimmed);
+      if (_recentSearches.length > 10) {
+        _recentSearches.removeLast();
+      }
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isSearching = false;
+      notifyListeners();
+    }
+  }
+
+  void clearSearch() {
+    _searchResults.clear();
+    _isSearching = false;
+    notifyListeners();
+  }
+
+  void setMaxAutoDownloadEpisodes(int value) {
+    if (value == _maxAutoDownloadEpisodes) {
+      return;
+    }
+    _maxAutoDownloadEpisodes = value.clamp(1, 10);
+    notifyListeners();
+  }
+
+  void _addToRecentlyPlayed(Episode episode) {
+    _recentlyPlayed.removeWhere((item) => item.id == episode.id);
+    _recentlyPlayed.insert(0, episode);
+    if (_recentlyPlayed.length > 20) {
+      _recentlyPlayed.removeLast();
+    }
+  }
+
+  Episode _mergeDownloadState(Episode episode) {
+    final existing = _downloadedEpisodes.firstWhere(
+      (downloaded) => downloaded.id == episode.id,
+      orElse: () => episode,
+    );
+    if (existing.localFilePath != null && existing.localFilePath!.isNotEmpty) {
+      return episode.copyWith(
+        isDownloaded: true,
+        localFilePath: existing.localFilePath,
+      );
+    }
+    return episode;
+  }
+
+  void _replaceEpisodeInCollections(Episode episode) {
+    final podcastEpisodes = _episodesByPodcast[episode.podcastId];
+    if (podcastEpisodes != null) {
+      for (var index = 0; index < podcastEpisodes.length; index++) {
+        if (podcastEpisodes[index].id == episode.id) {
+          podcastEpisodes[index] = episode;
+          break;
+        }
+      }
+    }
+
+    for (var index = 0; index < _recentlyPlayed.length; index++) {
+      if (_recentlyPlayed[index].id == episode.id) {
+        _recentlyPlayed[index] = episode;
+      }
+    }
+
+    for (var index = 0; index < _searchResults.length; index++) {
+      if (_searchResults[index].id == episode.id) {
+        _searchResults[index] = episode;
+      }
+    }
+
+    if (_nowPlaying?.id == episode.id) {
+      _nowPlaying = episode;
+    }
+  }
+
+  void _onPlayerStateChanged(PlayerState state) {
+    final playing = state.playing &&
+        state.processingState != ProcessingState.completed &&
+        state.processingState != ProcessingState.idle;
+    if (_isPlaying != playing) {
+      _isPlaying = playing;
+      notifyListeners();
+    }
+
+    if (state.processingState == ProcessingState.completed) {
+      _isPlaying = false;
+      _currentPosition = Duration.zero;
+      notifyListeners();
+    }
+  }
+
+  void _onPositionChanged(Duration position) {
+    _currentPosition = position;
+    if (_nowPlaying != null) {
+      _nowPlaying = _nowPlaying!.copyWith(playbackPosition: position);
+    }
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _playerStateSubscription.cancel();
+    _positionSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/klubradio_archivum/lib/providers/podcast_provider.dart
+++ b/klubradio_archivum/lib/providers/podcast_provider.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+import '../models/podcast.dart';
+import '../models/user_profile.dart';
+import '../services/api_service.dart';
+
+class PodcastProvider extends ChangeNotifier {
+  PodcastProvider({required ApiService apiService})
+      : _apiService = apiService,
+        _userProfile = const UserProfile(
+          id: 'hallgato-001',
+          displayName: 'Klubrádió Hallgató',
+          email: 'hallgato@example.com',
+          avatarUrl:
+              'https://images.klubradio.hu/archivum/default-avatar.png',
+          subscribedPodcastIds: <String>['esti-gyors', 'megbeszeljuk'],
+        ) {
+    _subscribedPodcastIds.addAll(_userProfile.subscribedPodcastIds);
+  }
+
+  ApiService _apiService;
+
+  final List<Podcast> _featuredPodcasts = <Podcast>[];
+  final List<Podcast> _trendingPodcasts = <Podcast>[];
+  final List<Podcast> _recommendedPodcasts = <Podcast>[];
+  final Set<String> _subscribedPodcastIds = <String>{};
+  final List<String> _topCategories = <String>[];
+
+  bool _isLoading = false;
+  String? _errorMessage;
+  UserProfile _userProfile;
+
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+
+  List<Podcast> get featuredPodcasts => List<Podcast>.unmodifiable(_featuredPodcasts);
+  List<Podcast> get trendingPodcasts => List<Podcast>.unmodifiable(_trendingPodcasts);
+  List<Podcast> get recommendedPodcasts =>
+      List<Podcast>.unmodifiable(_recommendedPodcasts);
+  List<String> get topCategories => List<String>.unmodifiable(_topCategories);
+  UserProfile get userProfile => _userProfile;
+
+  List<Podcast> get allPodcasts {
+    final Map<String, Podcast> combined = <String, Podcast>{};
+    for (final podcast in <Podcast>[
+      ..._featuredPodcasts,
+      ..._trendingPodcasts,
+      ..._recommendedPodcasts,
+    ]) {
+      combined[podcast.id] = podcast;
+    }
+    return combined.values.toList();
+  }
+
+  List<Podcast> get subscribedPodcasts => allPodcasts
+      .where((podcast) => _subscribedPodcastIds.contains(podcast.id))
+      .toList();
+
+  Future<void> loadHomeContent() async {
+    if (_isLoading) {
+      return;
+    }
+
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final results = await Future.wait<dynamic>(<Future<dynamic>>[
+        _apiService.fetchFeaturedPodcasts(),
+        _apiService.fetchTrendingPodcasts(),
+        _apiService.fetchRecommendedPodcasts(),
+        _apiService.fetchTopCategories(),
+      ]);
+
+      final featured = _withSubscriptionFlag(
+        (results[0] as List<Podcast>),
+      );
+      final trending = _withSubscriptionFlag(
+        (results[1] as List<Podcast>),
+      );
+      final recommended = _withSubscriptionFlag(
+        (results[2] as List<Podcast>),
+      );
+      final categories = (results[3] as List<String>);
+
+      _featuredPodcasts
+        ..clear()
+        ..addAll(featured);
+      _trendingPodcasts
+        ..clear()
+        ..addAll(trending);
+      _recommendedPodcasts
+        ..clear()
+        ..addAll(recommended);
+
+      _topCategories
+        ..clear()
+        ..addAll(categories);
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void updateApiService(ApiService apiService) {
+    if (identical(_apiService, apiService)) {
+      return;
+    }
+    _apiService = apiService;
+  }
+
+  void subscribeToPodcast(String podcastId) {
+    _subscribedPodcastIds.add(podcastId);
+    _updateSubscriptionFlags();
+    _userProfile = _userProfile.copyWith(
+      subscribedPodcastIds: _subscribedPodcastIds.toList(),
+    );
+    notifyListeners();
+  }
+
+  void unsubscribeFromPodcast(String podcastId) {
+    _subscribedPodcastIds.remove(podcastId);
+    _updateSubscriptionFlags();
+    _userProfile = _userProfile.copyWith(
+      subscribedPodcastIds: _subscribedPodcastIds.toList(),
+    );
+    notifyListeners();
+  }
+
+  bool isSubscribed(String podcastId) =>
+      _subscribedPodcastIds.contains(podcastId);
+
+  Podcast? findPodcastById(String podcastId) {
+    try {
+      return allPodcasts.firstWhere((podcast) => podcast.id == podcastId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void updateUserProfile(UserProfile profile) {
+    _userProfile = profile;
+    _subscribedPodcastIds
+      ..clear()
+      ..addAll(profile.subscribedPodcastIds);
+    _updateSubscriptionFlags();
+    notifyListeners();
+  }
+
+  List<Podcast> _withSubscriptionFlag(List<Podcast> podcasts) {
+    return podcasts
+        .map(
+          (podcast) => podcast.copyWith(
+            isSubscribed: _subscribedPodcastIds.contains(podcast.id),
+          ),
+        )
+        .toList();
+  }
+
+  void _updateSubscriptionFlags() {
+    void updateList(List<Podcast> list) {
+      for (var index = 0; index < list.length; index++) {
+        final podcast = list[index];
+        list[index] = podcast.copyWith(
+          isSubscribed: _subscribedPodcastIds.contains(podcast.id),
+        );
+      }
+    }
+
+    updateList(_featuredPodcasts);
+    updateList(_trendingPodcasts);
+    updateList(_recommendedPodcasts);
+  }
+}

--- a/klubradio_archivum/lib/providers/theme_provider.dart
+++ b/klubradio_archivum/lib/providers/theme_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeProvider();
+
+  ThemeMode _themeMode = ThemeMode.system;
+
+  ThemeMode get themeMode => _themeMode;
+
+  ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFFB71C1C),
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
+      );
+
+  ThemeData get darkTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFFEF9A9A),
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      );
+
+  bool get isDarkMode => _themeMode == ThemeMode.dark;
+
+  void setThemeMode(ThemeMode mode) {
+    if (_themeMode == mode) {
+      return;
+    }
+    _themeMode = mode;
+    notifyListeners();
+  }
+
+  void toggleDarkMode(bool enabled) {
+    setThemeMode(enabled ? ThemeMode.dark : ThemeMode.light);
+  }
+}

--- a/klubradio_archivum/lib/screens/about_screen/about_screen.dart
+++ b/klubradio_archivum/lib/screens/about_screen/about_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../utils/constants.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  static const String routeName = '/about';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Névjegy'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(kDefaultPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Klubrádió Archívum alkalmazás',
+              style: theme.textTheme.headlineSmall,
+            ),
+            const SizedBox(height: kDefaultPadding),
+            Text(
+              'Ez egy közösségi projekt, amely segít a Klubrádió archív tartalmainak '
+              'kényelmes elérésében, lejátszásában és RSS formátumba rendezésében.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: kDefaultPadding),
+            Text(
+              'A tartalmak mindenki számára ingyenesen hozzáférhetők. '
+              'Az alkalmazás nem áll kapcsolatban a Klubrádióval, '
+              'és nem kér semmilyen fizetést a műsorokért.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: kDefaultPadding),
+            Text(
+              'Verzió: 0.1.0 (fejlesztés alatt)\nFejlesztő: Klubrádió közösség',
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/discover_screen.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/discover_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart';
+import 'recommended_podcasts_list.dart';
+import 'top_categories_list.dart';
+import 'trending_podcasts_list.dart';
+
+class DiscoverScreen extends StatelessWidget {
+  const DiscoverScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Felfedezés'),
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          await context.read<PodcastProvider>().loadHomeContent();
+        },
+        child: Consumer<PodcastProvider>(
+          builder: (context, provider, _) {
+            if (provider.isLoading &&
+                provider.recommendedPodcasts.isEmpty &&
+                provider.trendingPodcasts.isEmpty) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            return ListView(
+              padding: const EdgeInsets.all(kDefaultPadding),
+              children: const <Widget>[
+                TopCategoriesList(),
+                SizedBox(height: kDefaultPadding),
+                RecommendedPodcastsList(),
+                SizedBox(height: kDefaultPadding),
+                TrendingPodcastsList(),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/recommended_podcasts_list.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/recommended_podcasts_list.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../podcast_detail_screen/podcast_detail_screen.dart';
+import '../utils/constants.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+
+class RecommendedPodcastsList extends StatelessWidget {
+  const RecommendedPodcastsList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (context, provider, _) {
+        final podcasts = provider.recommendedPodcasts;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Ajánlott műsorok', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            if (podcasts.isEmpty)
+              const Text('Jelenleg nincs ajánlott műsor.')
+            else
+              ListView.builder(
+                physics: const NeverScrollableScrollPhysics(),
+                shrinkWrap: true,
+                itemCount: podcasts.length,
+                itemBuilder: (context, index) {
+                  final podcast = podcasts[index];
+                  return PodcastListItem(
+                    podcast: podcast,
+                    onTap: () => Navigator.of(context).pushNamed(
+                      PodcastDetailScreen.routeName,
+                      arguments: PodcastDetailArguments(podcast: podcast),
+                    ),
+                    onSubscribeToggle: () {
+                      if (provider.isSubscribed(podcast.id)) {
+                        provider.unsubscribeFromPodcast(podcast.id);
+                      } else {
+                        provider.subscribeToPodcast(podcast.id);
+                      }
+                    },
+                  );
+                },
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/top_categories_list.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/top_categories_list.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart';
+
+class TopCategoriesList extends StatelessWidget {
+  const TopCategoriesList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (context, provider, _) {
+        final categories = provider.topCategories;
+        if (categories.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Témakörök', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            Wrap(
+              spacing: kSmallPadding,
+              runSpacing: kSmallPadding,
+              children: List<Widget>.generate(categories.length, (index) {
+                final label = categories[index];
+                final icon = kCategoryIcons[index % kCategoryIcons.length];
+                return FilterChip(
+                  label: Text(label, style: kChipTextStyle),
+                  avatar: Icon(icon, size: 18),
+                  selected: false,
+                  onSelected: (_) {},
+                );
+              }),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/trending_podcasts_list.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/trending_podcasts_list.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../podcast_detail_screen/podcast_detail_screen.dart';
+import '../utils/constants.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+
+class TrendingPodcastsList extends StatelessWidget {
+  const TrendingPodcastsList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (context, provider, _) {
+        final podcasts = provider.trendingPodcasts;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Felkapott műsorok', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            if (podcasts.isEmpty)
+              const Text('Jelenleg nincs felkapott műsor.')
+            else
+              ListView.builder(
+                physics: const NeverScrollableScrollPhysics(),
+                shrinkWrap: true,
+                itemCount: podcasts.length,
+                itemBuilder: (context, index) {
+                  final podcast = podcasts[index];
+                  return PodcastListItem(
+                    podcast: podcast,
+                    onTap: () => Navigator.of(context).pushNamed(
+                      PodcastDetailScreen.routeName,
+                      arguments: PodcastDetailArguments(podcast: podcast),
+                    ),
+                    onSubscribeToggle: () {
+                      if (provider.isSubscribed(podcast.id)) {
+                        provider.unsubscribeFromPodcast(podcast.id);
+                      } else {
+                        provider.subscribeToPodcast(podcast.id);
+                      }
+                    },
+                  );
+                },
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/download_manager_screen/download_list.dart
+++ b/klubradio_archivum/lib/screens/download_manager_screen/download_list.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../providers/episode_provider.dart';
+import '../utils/constants.dart';
+import '../widgets/stateless/episode_list_item.dart';
+
+class DownloadList extends StatelessWidget {
+  const DownloadList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final List<Episode> downloads = provider.downloadedEpisodes;
+        if (downloads.isEmpty) {
+          return const Center(
+            child: Padding(
+              padding: EdgeInsets.all(kDefaultPadding),
+              child: Text('Nem található letöltött epizód.'),
+            ),
+          );
+        }
+
+        return ListView.separated(
+          itemCount: downloads.length,
+          separatorBuilder: (_, __) => const SizedBox(height: kSmallPadding),
+          itemBuilder: (context, index) {
+            final episode = downloads[index];
+            return EpisodeListItem(
+              episode: episode,
+              downloadProgress: provider.downloadProgress[episode.id],
+              onPlay: () => provider.playEpisode(episode),
+              onRemoveDownload: () => provider.removeDownload(episode),
+              onDownload: null,
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/download_manager_screen/download_manager_screen.dart
+++ b/klubradio_archivum/lib/screens/download_manager_screen/download_manager_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+import '../utils/constants.dart';
+import 'download_list.dart';
+
+class DownloadManagerScreen extends StatelessWidget {
+  const DownloadManagerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(
+        title: Text('Letöltések'),
+      ),
+      body: Padding(
+        padding: EdgeInsets.all(kDefaultPadding),
+        child: DownloadList(),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/home_screen/home_screen.dart
+++ b/klubradio_archivum/lib/screens/home_screen/home_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../podcast_detail_screen/podcast_detail_screen.dart';
+import '../search_screen/search_screen.dart';
+import '../utils/constants.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+import 'recently_played_list.dart';
+import 'subscribed_podcasts_list.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Klubrádió Archívum'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.search),
+            tooltip: 'Keresés',
+            onPressed: () => Navigator.of(context).pushNamed(
+              SearchScreen.routeName,
+            ),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          await context.read<PodcastProvider>().loadHomeContent();
+        },
+        child: Consumer<PodcastProvider>(
+          builder: (context, provider, _) {
+            if (provider.isLoading && provider.featuredPodcasts.isEmpty) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final featured = provider.featuredPodcasts;
+
+            return SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(kDefaultPadding),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  const SubscribedPodcastsList(),
+                  const SizedBox(height: kDefaultPadding),
+                  const RecentlyPlayedList(),
+                  const SizedBox(height: kDefaultPadding),
+                  Text('Kiemelt műsorok', style: kSectionTitleStyle),
+                  const SizedBox(height: kSmallPadding),
+                  if (featured.isEmpty)
+                    const Text('A kiemelt műsorok listája jelenleg üres.')
+                  else
+                    ListView.builder(
+                      physics: const NeverScrollableScrollPhysics(),
+                      shrinkWrap: true,
+                      itemCount: featured.length,
+                      itemBuilder: (context, index) {
+                        final podcast = featured[index];
+                        return PodcastListItem(
+                          podcast: podcast,
+                          onTap: () => Navigator.of(context).pushNamed(
+                            PodcastDetailScreen.routeName,
+                            arguments: PodcastDetailArguments(podcast: podcast),
+                          ),
+                          onSubscribeToggle: () {
+                            if (provider.isSubscribed(podcast.id)) {
+                              provider.unsubscribeFromPodcast(podcast.id);
+                            } else {
+                              provider.subscribeToPodcast(podcast.id);
+                            }
+                          },
+                        );
+                      },
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/home_screen/recently_played_list.dart
+++ b/klubradio_archivum/lib/screens/home_screen/recently_played_list.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../providers/episode_provider.dart';
+import '../now_playing_screen/now_playing_screen.dart';
+import '../utils/constants.dart';
+import '../utils/helpers.dart';
+
+class RecentlyPlayedList extends StatelessWidget {
+  const RecentlyPlayedList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final List<Episode> episodes = provider.recentlyPlayed;
+        if (episodes.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Nemrég hallgatott epizódok', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            SizedBox(
+              height: 160,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                itemCount: episodes.length,
+                separatorBuilder: (_, __) => const SizedBox(width: kSmallPadding),
+                itemBuilder: (context, index) {
+                  final episode = episodes[index];
+                  return _RecentlyPlayedCard(episode: episode);
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _RecentlyPlayedCard extends StatelessWidget {
+  const _RecentlyPlayedCard({required this.episode});
+
+  final Episode episode;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return GestureDetector(
+      onTap: () {
+        context.read<EpisodeProvider>().playEpisode(episode);
+        Navigator.of(context).pushNamed(NowPlayingScreen.routeName);
+      },
+      child: Container(
+        width: 220,
+        padding: const EdgeInsets.all(kSmallPadding),
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceVariant,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                episode.title,
+                style: theme.textTheme.titleMedium,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              formatRelativeTime(episode.publishedAt),
+              style: theme.textTheme.bodySmall,
+            ),
+            Text(
+              formatDuration(episode.duration),
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/home_screen/subscribed_podcasts_list.dart
+++ b/klubradio_archivum/lib/screens/home_screen/subscribed_podcasts_list.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/podcast.dart';
+import '../../providers/podcast_provider.dart';
+import '../podcast_detail_screen/podcast_detail_screen.dart';
+import '../utils/constants.dart';
+
+class SubscribedPodcastsList extends StatelessWidget {
+  const SubscribedPodcastsList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (context, provider, _) {
+        final List<Podcast> podcasts = provider.subscribedPodcasts;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Feliratkozott műsorok', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            if (podcasts.isEmpty)
+              const Text('Még nem iratkoztál fel műsorokra.')
+            else
+              SizedBox(
+                height: 56,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: podcasts.length,
+                  separatorBuilder: (_, __) => const SizedBox(width: kSmallPadding),
+                  itemBuilder: (context, index) {
+                    final podcast = podcasts[index];
+                    return ActionChip(
+                      label: Text(podcast.title, style: kChipTextStyle),
+                      avatar: podcast.coverImageUrl.isNotEmpty
+                          ? CircleAvatar(
+                              backgroundImage: NetworkImage(podcast.coverImageUrl),
+                            )
+                          : const CircleAvatar(child: Icon(Icons.podcasts)),
+                      onPressed: () => Navigator.of(context).pushNamed(
+                        PodcastDetailScreen.routeName,
+                        arguments: PodcastDetailArguments(podcast: podcast),
+                      ),
+                    );
+                  },
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/now_playing_screen/audio_player_controls.dart
+++ b/klubradio_archivum/lib/screens/now_playing_screen/audio_player_controls.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode_provider.dart';
+
+class AudioPlayerControls extends StatelessWidget {
+  const AudioPlayerControls({super.key});
+
+  static const Duration _skipInterval = Duration(seconds: 15);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final hasEpisode = provider.nowPlaying != null;
+        final isPlaying = provider.isPlaying;
+
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            IconButton(
+              iconSize: 36,
+              icon: const Icon(Icons.replay_10),
+              onPressed: hasEpisode
+                  ? () {
+                      final newPosition = provider.currentPosition - _skipInterval;
+                      provider.seek(newPosition.isNegative
+                          ? Duration.zero
+                          : newPosition);
+                    }
+                  : null,
+              tooltip: 'Vissza 15 másodperc',
+            ),
+            const SizedBox(width: 12),
+            IconButton(
+              iconSize: 56,
+              icon: Icon(
+                isPlaying ? Icons.pause_circle_filled : Icons.play_circle_fill,
+              ),
+              onPressed: hasEpisode ? provider.togglePlayPause : null,
+              tooltip: isPlaying ? 'Szünet' : 'Lejátszás',
+            ),
+            const SizedBox(width: 12),
+            IconButton(
+              iconSize: 36,
+              icon: const Icon(Icons.forward_10),
+              onPressed: hasEpisode
+                  ? () {
+                      final duration = provider.nowPlaying?.duration ?? Duration.zero;
+                      final newPosition =
+                          provider.currentPosition + _skipInterval;
+                      provider.seek(newPosition > duration
+                          ? duration
+                          : newPosition);
+                    }
+                  : null,
+              tooltip: 'Előre 15 másodperc',
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/now_playing_screen/now_playing_screen.dart
+++ b/klubradio_archivum/lib/screens/now_playing_screen/now_playing_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../providers/episode_provider.dart';
+import '../utils/constants.dart';
+import '../utils/helpers.dart';
+import 'audio_player_controls.dart';
+import 'progress_slider.dart';
+
+class NowPlayingScreen extends StatelessWidget {
+  const NowPlayingScreen({super.key});
+
+  static const String routeName = '/now-playing';
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final Episode? episode = provider.nowPlaying;
+        if (episode == null) {
+          return const Scaffold(
+            body: Center(child: Text('Jelenleg nincs lejátszott epizód.')),
+          );
+        }
+
+        final theme = Theme.of(context);
+        final colorScheme = theme.colorScheme;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Most szól'),
+            actions: <Widget>[
+              IconButton(
+                icon: Icon(
+                  episode.isDownloaded ? Icons.download_done : Icons.download,
+                ),
+                tooltip: episode.isDownloaded
+                    ? 'Letöltés törlése'
+                    : 'Letöltés offline meghallgatáshoz',
+                onPressed: episode.isDownloaded
+                    ? () => provider.removeDownload(episode)
+                    : () => provider.downloadEpisode(episode),
+              ),
+            ],
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(kDefaultPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                if (episode.imageUrl.isNotEmpty)
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(24),
+                    child: Image.network(
+                      episode.imageUrl,
+                      height: 240,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    ),
+                  )
+                else
+                  Container(
+                    height: 240,
+                    width: double.infinity,
+                    decoration: BoxDecoration(
+                      color: colorScheme.surfaceVariant,
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    child: Icon(Icons.podcasts, size: 96, color: colorScheme.primary),
+                  ),
+                const SizedBox(height: kDefaultPadding),
+                Text(
+                  episode.title,
+                  style: theme.textTheme.headlineSmall,
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: kSmallPadding),
+                Text(
+                  formatDateTime(episode.publishedAt),
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: kDefaultPadding),
+                const ProgressSlider(),
+                const SizedBox(height: kDefaultPadding),
+                const AudioPlayerControls(),
+                const SizedBox(height: kDefaultPadding),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Text(
+                      episode.description.isEmpty
+                          ? 'Ehhez az epizódhoz nem tartozik leírás.'
+                          : episode.description,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/now_playing_screen/progress_slider.dart
+++ b/klubradio_archivum/lib/screens/now_playing_screen/progress_slider.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode_provider.dart';
+import '../utils/helpers.dart';
+
+class ProgressSlider extends StatefulWidget {
+  const ProgressSlider({super.key});
+
+  @override
+  State<ProgressSlider> createState() => _ProgressSliderState();
+}
+
+class _ProgressSliderState extends State<ProgressSlider> {
+  double? _dragValue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final episode = provider.nowPlaying;
+        final duration = episode?.duration ?? Duration.zero;
+        final durationSeconds = duration.inSeconds;
+        final currentPosition = _dragValue != null
+            ? Duration(seconds: _dragValue!.round())
+            : provider.currentPosition;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Slider(
+              value: durationSeconds == 0
+                  ? 0
+                  : currentPosition.inSeconds
+                      .clamp(0, durationSeconds)
+                      .toDouble(),
+              min: 0,
+              max: durationSeconds == 0 ? 1 : durationSeconds.toDouble(),
+              onChanged: episode == null
+                  ? null
+                  : (value) {
+                      setState(() {
+                        _dragValue = value;
+                      });
+                    },
+              onChangeEnd: episode == null
+                  ? null
+                  : (value) {
+                      setState(() {
+                        _dragValue = null;
+                      });
+                      provider.seek(Duration(seconds: value.round()));
+                    },
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(formatDuration(currentPosition)),
+                Text(formatDuration(duration)),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_detail_screen.dart
+++ b/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_detail_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/podcast.dart';
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart';
+import '../widgets/stateful/episode_list.dart';
+import 'podcast_info_card.dart';
+
+class PodcastDetailArguments {
+  const PodcastDetailArguments({required this.podcast});
+
+  final Podcast podcast;
+}
+
+class PodcastDetailScreen extends StatelessWidget {
+  const PodcastDetailScreen({super.key, required this.podcast});
+
+  static const String routeName = '/podcast-detail';
+
+  final Podcast podcast;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(podcast.title),
+        actions: <Widget>[
+          Consumer<PodcastProvider>(
+            builder: (context, provider, _) {
+              final subscribed = provider.isSubscribed(podcast.id);
+              return IconButton(
+                icon: Icon(subscribed ? Icons.favorite : Icons.favorite_border),
+                tooltip: subscribed ? 'Leiratkozás' : 'Feliratkozás',
+                onPressed: () {
+                  if (subscribed) {
+                    provider.unsubscribeFromPodcast(podcast.id);
+                  } else {
+                    provider.subscribeToPodcast(podcast.id);
+                  }
+                },
+              );
+            },
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(kDefaultPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            PodcastInfoCard(podcast: podcast),
+            const SizedBox(height: kDefaultPadding),
+            Text('Epizódok', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            EpisodeList(
+              podcastId: podcast.id,
+              podcastTitle: podcast.title,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_info_card.dart
+++ b/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_info_card.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+
+import '../../models/podcast.dart';
+import '../utils/constants.dart';
+import '../utils/helpers.dart';
+
+class PodcastInfoCard extends StatelessWidget {
+  const PodcastInfoCard({super.key, required this.podcast});
+
+  final Podcast podcast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Card(
+      elevation: kCardElevation,
+      child: Padding(
+        padding: const EdgeInsets.all(kDefaultPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(16),
+                  child: podcast.coverImageUrl.isNotEmpty
+                      ? Image.network(
+                          podcast.coverImageUrl,
+                          width: 120,
+                          height: 120,
+                          fit: BoxFit.cover,
+                        )
+                      : Container(
+                          width: 120,
+                          height: 120,
+                          color: colorScheme.surfaceVariant,
+                          child: Icon(Icons.podcasts, size: 48, color: colorScheme.primary),
+                        ),
+                ),
+                const SizedBox(width: kDefaultPadding),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        podcast.title,
+                        style: theme.textTheme.headlineSmall,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '${podcast.category} · ${podcast.episodeCount} epizód',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      if (podcast.hosts.isNotEmpty)
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 4,
+                          children: podcast.hosts
+                              .map(
+                                (host) => Chip(
+                                  avatar: host.avatarUrl.isNotEmpty
+                                      ? CircleAvatar(
+                                          backgroundImage:
+                                              NetworkImage(host.avatarUrl),
+                                        )
+                                      : const CircleAvatar(child: Icon(Icons.mic)),
+                                  label: Text(host.name),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: kDefaultPadding),
+            Text(
+              podcast.description.isEmpty
+                  ? 'Ehhez a műsorhoz nem tartozik részletes leírás.'
+                  : ellipsize(podcast.description, maxLength: 220),
+              style: theme.textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/profile_screen/profile_screen.dart
+++ b/klubradio_archivum/lib/screens/profile_screen/profile_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode_provider.dart';
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (context, provider, _) {
+        final profile = provider.userProfile;
+        final theme = Theme.of(context);
+        final downloadedCount =
+            context.watch<EpisodeProvider>().downloadedEpisodes.length;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Profil'),
+          ),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(kDefaultPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    CircleAvatar(
+                      radius: kLargeAvatarRadius,
+                      backgroundImage: profile.avatarUrl.isNotEmpty
+                          ? NetworkImage(profile.avatarUrl)
+                          : null,
+                      child: profile.avatarUrl.isEmpty
+                          ? const Icon(Icons.person)
+                          : null,
+                    ),
+                    const SizedBox(width: kDefaultPadding),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          profile.displayName,
+                          style: theme.textTheme.headlineSmall,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          profile.email,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: kDefaultPadding),
+                Card(
+                  child: ListTile(
+                    leading: const Icon(Icons.favorite),
+                    title: const Text('Feliratkozott műsorok'),
+                    trailing: Text(
+                      provider.subscribedPodcasts.length.toString(),
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                ),
+                Card(
+                  child: ListTile(
+                    leading: const Icon(Icons.download),
+                    title: const Text('Letöltött epizódok'),
+                    trailing: Text(
+                      downloadedCount.toString(),
+                      style: theme.textTheme.titleMedium,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: kDefaultPadding),
+                Text(
+                  kPaymentWarningText,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/recent_searches.dart
+++ b/klubradio_archivum/lib/screens/search_screen/recent_searches.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode_provider.dart';
+import '../utils/constants.dart';
+
+class RecentSearches extends StatelessWidget {
+  const RecentSearches({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final searches = provider.recentSearches;
+        if (searches.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text('Legutóbbi keresések', style: kSectionTitleStyle),
+            const SizedBox(height: kSmallPadding),
+            Wrap(
+              spacing: kSmallPadding,
+              runSpacing: kSmallPadding,
+              children: searches
+                  .map(
+                    (query) => ActionChip(
+                      label: Text(query),
+                      onPressed: () =>
+                          context.read<EpisodeProvider>().searchEpisodes(query),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/search_bar.dart
+++ b/klubradio_archivum/lib/screens/search_screen/search_bar.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import '../utils/constants.dart';
+
+class SearchInputBar extends StatelessWidget {
+  const SearchInputBar({
+    super.key,
+    required this.controller,
+    required this.onChanged,
+    required this.onClear,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: controller,
+      builder: (context, value, _) {
+        return TextField(
+          controller: controller,
+          textInputAction: TextInputAction.search,
+          onChanged: onChanged,
+          decoration: InputDecoration(
+            hintText: 'Keresés cím, téma vagy műsor alapján',
+            prefixIcon: const Icon(Icons.search),
+            suffixIcon: value.text.isEmpty
+                ? null
+                : IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: onClear,
+                  ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(kDefaultPadding),
+            ),
+            filled: true,
+            fillColor: theme.colorScheme.surfaceVariant,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/search_results_list.dart
+++ b/klubradio_archivum/lib/screens/search_screen/search_results_list.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../providers/episode_provider.dart';
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart';
+import '../widgets/stateless/episode_list_item.dart';
+
+class SearchResultsList extends StatelessWidget {
+  const SearchResultsList({super.key, required this.episodes});
+
+  final List<Episode> episodes;
+
+  @override
+  Widget build(BuildContext context) {
+    final episodeProvider = context.read<EpisodeProvider>();
+    final podcastProvider = context.read<PodcastProvider>();
+
+    return ListView.separated(
+      itemCount: episodes.length,
+      separatorBuilder: (_, __) => const SizedBox(height: kSmallPadding),
+      itemBuilder: (context, index) {
+        final episode = episodes[index];
+        final podcastTitle = podcastProvider
+                .findPodcastById(episode.podcastId)
+                ?.title ??
+            episode.podcastId;
+
+        return EpisodeListItem(
+          episode: episode,
+          onPlay: () => episodeProvider.playEpisode(episode),
+          onDownload: () => episodeProvider.downloadEpisode(episode),
+          onRemoveDownload: () => episodeProvider.removeDownload(episode),
+          downloadProgress: episodeProvider.downloadProgress[episode.id],
+          showPodcastTitle: true,
+          podcastTitle: podcastTitle,
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/search_screen.dart
+++ b/klubradio_archivum/lib/screens/search_screen/search_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode_provider.dart';
+import '../utils/constants.dart';
+import 'recent_searches.dart';
+import 'search_bar.dart';
+import 'search_results_list.dart';
+
+class SearchScreen extends StatefulWidget {
+  const SearchScreen({super.key});
+
+  static const String routeName = '/search';
+
+  @override
+  State<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends State<SearchScreen> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Keresés az archívumban'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(kDefaultPadding),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SearchInputBar(
+              controller: _controller,
+              onChanged: (value) {
+                context.read<EpisodeProvider>().searchEpisodes(value);
+              },
+              onClear: () {
+                _controller.clear();
+                context.read<EpisodeProvider>().clearSearch();
+              },
+            ),
+            const SizedBox(height: kDefaultPadding),
+            const RecentSearches(),
+            const SizedBox(height: kDefaultPadding),
+            Expanded(
+              child: Consumer<EpisodeProvider>(
+                builder: (context, provider, _) {
+                  if (provider.isSearching) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+
+                  final episodes = provider.searchResults;
+                  if (episodes.isEmpty) {
+                    return const Center(
+                      child: Text('Nincs találat. Próbálj meg másik kulcsszót.'),
+                    );
+                  }
+
+                  return SearchResultsList(episodes: episodes);
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/settings_screen/playback_settings.dart
+++ b/klubradio_archivum/lib/screens/settings_screen/playback_settings.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode_provider.dart';
+import '../utils/constants.dart';
+
+class PlaybackSettings extends StatelessWidget {
+  const PlaybackSettings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final currentValue = provider.maxAutoDownloadEpisodes.toDouble();
+
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(kDefaultPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text('Lejátszás és letöltés', style: Theme.of(context).textTheme.titleLarge),
+                const SizedBox(height: kSmallPadding),
+                Text(
+                  'Állítsd be, hogy hány új epizód töltődjön le automatikusan a feliratkozott műsorokból.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: kSmallPadding),
+                Slider(
+                  value: currentValue,
+                  min: 1,
+                  max: 10,
+                  divisions: 9,
+                  label: provider.maxAutoDownloadEpisodes.toString(),
+                  onChanged: (value) => provider
+                      .setMaxAutoDownloadEpisodes(value.round()),
+                ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    '${provider.maxAutoDownloadEpisodes} epizód',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/settings_screen/settings_screen.dart
+++ b/klubradio_archivum/lib/screens/settings_screen/settings_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+// TODO: Declare the url_launcher dependency in pubspec.yaml if it is missing.
+
+import '../about_screen/about_screen.dart';
+import '../utils/constants.dart';
+import 'playback_settings.dart';
+import 'theme_settings.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  static const String routeName = '/settings';
+
+  Future<void> _launchExternalUrl(String url) async {
+    final uri = Uri.parse(url);
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      throw Exception('Nem sikerült megnyitni a hivatkozást: $url');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Beállítások'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(kDefaultPadding),
+        children: <Widget>[
+          const ThemeSettings(),
+          const SizedBox(height: kDefaultPadding),
+          const PlaybackSettings(),
+          const SizedBox(height: kDefaultPadding),
+          ListTile(
+            leading: const Icon(Icons.volunteer_activism),
+            title: const Text('Támogasd a Klubrádiót'),
+            subtitle: const Text('A hivatalos Klubrádió támogatási oldalra visz.'),
+            onTap: () => _launchExternalUrl(kDonationUrlStation),
+          ),
+          ListTile(
+            leading: const Icon(Icons.favorite),
+            title: const Text('Támogasd az alkalmazás fejlesztését'),
+            subtitle: const Text('PayPal adomány a fejlesztőnek.'),
+            onTap: () => _launchExternalUrl(kDonationUrlDeveloper),
+          ),
+          ListTile(
+            leading: const Icon(Icons.info_outline),
+            title: const Text('Névjegy'),
+            onTap: () => Navigator.of(context).pushNamed(AboutScreen.routeName),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/settings_screen/theme_settings.dart
+++ b/klubradio_archivum/lib/screens/settings_screen/theme_settings.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/theme_provider.dart';
+import '../utils/constants.dart';
+
+class ThemeSettings extends StatelessWidget {
+  const ThemeSettings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ThemeProvider>(
+      builder: (context, provider, _) {
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(kDefaultPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text('Téma', style: Theme.of(context).textTheme.titleLarge),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Rendszer alapértelmezett'),
+                  value: ThemeMode.system,
+                  groupValue: provider.themeMode,
+                  onChanged: provider.setThemeMode,
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Világos mód'),
+                  value: ThemeMode.light,
+                  groupValue: provider.themeMode,
+                  onChanged: provider.setThemeMode,
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Sötét mód'),
+                  value: ThemeMode.dark,
+                  groupValue: provider.themeMode,
+                  onChanged: provider.setThemeMode,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/utils/constants.dart
+++ b/klubradio_archivum/lib/screens/utils/constants.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+const double kDefaultPadding = 16;
+const double kSmallPadding = 8;
+const double kCardElevation = 1.5;
+const double kListItemSpacing = 12;
+const double kLargeAvatarRadius = 36;
+
+const Duration kShortAnimationDuration = Duration(milliseconds: 250);
+const Duration kMediumAnimationDuration = Duration(milliseconds: 400);
+
+const String kDonationUrlDeveloper =
+    'https://www.paypal.com/paypalme/klubradioapp';
+const String kDonationUrlStation = 'https://klubradio.hu/tamogasson-minket';
+
+const List<IconData> kCategoryIcons = <IconData>[
+  Icons.public,
+  Icons.mic,
+  Icons.newspaper,
+  Icons.theaters,
+  Icons.sports_soccer,
+  Icons.science,
+  Icons.music_note,
+  Icons.policy,
+];
+
+const TextStyle kSectionTitleStyle = TextStyle(
+  fontSize: 20,
+  fontWeight: FontWeight.w700,
+);
+
+const TextStyle kSubtitleStyle = TextStyle(
+  fontSize: 14,
+  color: Colors.black87,
+);
+
+const TextStyle kSecondaryTextStyle = TextStyle(
+  fontSize: 12,
+  color: Colors.black54,
+);
+
+const TextStyle kChipTextStyle = TextStyle(
+  fontSize: 13,
+  fontWeight: FontWeight.w600,
+);
+
+const String kPaymentWarningText =
+    'Figyelem! A Klubrádió tartalmai ingyenesen elérhetők. Ha fizetési kérésbe '
+    'botlik, az biztosan nem a Klubrádiótól származik.';

--- a/klubradio_archivum/lib/screens/utils/helpers.dart
+++ b/klubradio_archivum/lib/screens/utils/helpers.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+String formatDuration(Duration duration) {
+  final totalSeconds = duration.inSeconds;
+  final hours = totalSeconds ~/ 3600;
+  final minutes = (totalSeconds % 3600) ~/ 60;
+  final seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    final hourStr = hours.toString().padLeft(2, '0');
+    final minuteStr = minutes.toString().padLeft(2, '0');
+    final secondStr = seconds.toString().padLeft(2, '0');
+    return '$hourStr:$minuteStr:$secondStr';
+  }
+
+  final minuteStr = minutes.toString().padLeft(2, '0');
+  final secondStr = seconds.toString().padLeft(2, '0');
+  return '$minuteStr:$secondStr';
+}
+
+String formatDate(DateTime date) {
+  return '${date.year}. '
+      '${date.month.toString().padLeft(2, '0')}. '
+      '${date.day.toString().padLeft(2, '0')}.';
+}
+
+String formatDateTime(DateTime dateTime) {
+  final date = formatDate(dateTime);
+  final time = '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  return '$date $time';
+}
+
+String formatRelativeTime(DateTime date) {
+  final now = DateTime.now();
+  final difference = now.difference(date);
+
+  if (difference.inMinutes.abs() < 1) {
+    return 'Az imént';
+  }
+  if (difference.inHours < 1) {
+    return '${difference.inMinutes} perce';
+  }
+  if (difference.inHours < 24) {
+    return '${difference.inHours} órája';
+  }
+  if (difference.inDays == 1) {
+    return 'Tegnap';
+  }
+  if (difference.inDays < 7) {
+    return '${difference.inDays} napja';
+  }
+  return formatDate(date);
+}
+
+String ellipsize(String text, {int maxLength = 140}) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return '${text.substring(0, maxLength - 1)}…';
+}
+
+String formatDownloadPercentage(double progress) {
+  final percentage = (progress * 100).clamp(0, 100).toStringAsFixed(0);
+  return '$percentage%';
+}
+
+Color progressColor(double progress, ColorScheme colorScheme) {
+  if (progress >= 1) {
+    return colorScheme.primary;
+  }
+  if (progress > 0.5) {
+    return colorScheme.tertiary;
+  }
+  return colorScheme.secondary;
+}

--- a/klubradio_archivum/lib/screens/widgets/stateful/episode_list.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateful/episode_list.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../models/episode.dart';
+import '../../../providers/episode_provider.dart';
+import '../../utils/constants.dart';
+import '../stateless/episode_list_item.dart';
+
+class EpisodeList extends StatefulWidget {
+  const EpisodeList({
+    super.key,
+    required this.podcastId,
+    this.podcastTitle,
+  });
+
+  final String podcastId;
+  final String? podcastTitle;
+
+  @override
+  State<EpisodeList> createState() => _EpisodeListState();
+}
+
+class _EpisodeListState extends State<EpisodeList> {
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() {
+      context
+          .read<EpisodeProvider>()
+          .loadEpisodesForPodcast(widget.podcastId);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final List<Episode> episodes =
+            provider.episodesForPodcast(widget.podcastId);
+        final isLoading = provider.isLoading && episodes.isEmpty;
+
+        if (isLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (episodes.isEmpty) {
+          return const Center(
+            child: Padding(
+              padding: EdgeInsets.all(kDefaultPadding),
+              child: Text('Jelenleg nincsenek elérhető epizódok.'),
+            ),
+          );
+        }
+
+        return ListView.separated(
+          physics: const NeverScrollableScrollPhysics(),
+          shrinkWrap: true,
+          itemCount: episodes.length,
+          separatorBuilder: (_, __) => const SizedBox(height: kSmallPadding),
+          itemBuilder: (context, index) {
+            final episode = episodes[index];
+            final progress = provider.downloadProgress[episode.id];
+            return EpisodeListItem(
+              episode: episode,
+              podcastTitle: widget.podcastTitle,
+              showPodcastTitle: widget.podcastTitle != null,
+              downloadProgress: progress,
+              onPlay: () => provider.playEpisode(episode),
+              onDownload: () => provider.downloadEpisode(episode),
+              onRemoveDownload: () => provider.removeDownload(episode),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateful/now_playing_bar.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateful/now_playing_bar.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../models/episode.dart';
+import '../../../providers/episode_provider.dart';
+import '../../now_playing_screen/now_playing_screen.dart';
+import '../../utils/constants.dart';
+import '../../utils/helpers.dart';
+
+class NowPlayingBar extends StatelessWidget {
+  const NowPlayingBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (context, provider, _) {
+        final Episode? episode = provider.nowPlaying;
+        if (episode == null) {
+          return const SizedBox.shrink();
+        }
+
+        final theme = Theme.of(context);
+        final position = provider.currentPosition;
+        final progress = episode.duration.inSeconds > 0
+            ? (position.inSeconds / episode.duration.inSeconds).clamp(0.0, 1.0)
+            : 0.0;
+
+        return Material(
+          elevation: 8,
+          color: theme.colorScheme.surface,
+          child: InkWell(
+            onTap: () => Navigator.of(context)
+                .pushNamed(NowPlayingScreen.routeName),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: kDefaultPadding,
+                vertical: kSmallPadding,
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      IconButton(
+                        onPressed: provider.togglePlayPause,
+                        iconSize: 32,
+                        icon: Icon(
+                          provider.isPlaying
+                              ? Icons.pause_circle_filled
+                              : Icons.play_circle_fill,
+                        ),
+                      ),
+                      const SizedBox(width: kSmallPadding),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Text(
+                              episode.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodyLarge,
+                            ),
+                            Text(
+                              '${formatRelativeTime(episode.publishedAt)} · ${formatDuration(episode.duration)}',
+                              style: theme.textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        onPressed: () => Navigator.of(context)
+                            .pushNamed(NowPlayingScreen.routeName),
+                        icon: const Icon(Icons.open_in_full),
+                      ),
+                    ],
+                  ),
+                  LinearProgressIndicator(
+                    value: progress,
+                    backgroundColor: theme.colorScheme.surfaceVariant,
+                    color: theme.colorScheme.primary,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateless/app_bottom_navigation_bar.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateless/app_bottom_navigation_bar.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class AppBottomNavigationBar extends StatelessWidget {
+  const AppBottomNavigationBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: onTap,
+      type: BottomNavigationBarType.fixed,
+      showUnselectedLabels: false,
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(
+          icon: Icon(Icons.home_outlined),
+          activeIcon: Icon(Icons.home),
+          label: 'Főoldal',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.explore_outlined),
+          activeIcon: Icon(Icons.explore),
+          label: 'Felfedezés',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.download_outlined),
+          activeIcon: Icon(Icons.download),
+          label: 'Letöltések',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.person_outline),
+          activeIcon: Icon(Icons.person),
+          label: 'Profil',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.settings_outlined),
+          activeIcon: Icon(Icons.settings),
+          label: 'Beállítások',
+        ),
+      ],
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateless/episode_list_item.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateless/episode_list_item.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/episode.dart';
+import '../../utils/constants.dart';
+import '../../utils/helpers.dart';
+
+class EpisodeListItem extends StatelessWidget {
+  const EpisodeListItem({
+    super.key,
+    required this.episode,
+    this.onPlay,
+    this.onDownload,
+    this.onRemoveDownload,
+    this.onTap,
+    this.downloadProgress,
+    this.showPodcastTitle = false,
+    this.podcastTitle,
+  });
+
+  final Episode episode;
+  final VoidCallback? onPlay;
+  final VoidCallback? onDownload;
+  final VoidCallback? onRemoveDownload;
+  final VoidCallback? onTap;
+  final double? downloadProgress;
+  final bool showPodcastTitle;
+  final String? podcastTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final durationText = formatDuration(episode.duration);
+    final dateText = formatDate(episode.publishedAt);
+    final relative = formatRelativeTime(episode.publishedAt);
+
+    final subtitleText = <String>[
+      if (showPodcastTitle && (podcastTitle?.isNotEmpty ?? false))
+        podcastTitle!,
+      '$dateText · $durationText',
+      relative,
+    ].where((value) => value.isNotEmpty).join(' · ');
+
+    final progress = downloadProgress ??
+        (episode.playbackPosition.inSeconds > 0 &&
+                episode.duration.inSeconds > 0
+            ? episode.playbackPosition.inSeconds / episode.duration.inSeconds
+            : null);
+
+    return Card(
+      elevation: kCardElevation,
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: InkWell(
+        onTap: onTap ?? onPlay,
+        child: Padding(
+          padding: const EdgeInsets.all(kSmallPadding),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  IconButton(
+                    onPressed: onPlay,
+                    icon: const Icon(Icons.play_arrow_rounded),
+                    tooltip: 'Lejátszás',
+                  ),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          episode.title,
+                          style: theme.textTheme.titleMedium,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          subtitleText,
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: kSmallPadding),
+                  _DownloadButton(
+                    isDownloaded: episode.isDownloaded,
+                    onDownload: onDownload,
+                    onRemoveDownload: onRemoveDownload,
+                  ),
+                ],
+              ),
+              if (progress != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: LinearProgressIndicator(
+                    value: progress.clamp(0, 1),
+                    color: progressColor(progress, colorScheme),
+                    backgroundColor: colorScheme.surfaceVariant,
+                  ),
+                ),
+              if (episode.description.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    ellipsize(episode.description, maxLength: 150),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DownloadButton extends StatelessWidget {
+  const _DownloadButton({
+    required this.isDownloaded,
+    this.onDownload,
+    this.onRemoveDownload,
+  });
+
+  final bool isDownloaded;
+  final VoidCallback? onDownload;
+  final VoidCallback? onRemoveDownload;
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: isDownloaded ? onRemoveDownload : onDownload,
+      tooltip: isDownloaded ? 'Letöltés törlése' : 'Letöltés offline meghallgatáshoz',
+      icon: Icon(isDownloaded ? Icons.download_done : Icons.download),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateless/podcast_list_item.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateless/podcast_list_item.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/podcast.dart';
+import '../../utils/constants.dart';
+import '../../utils/helpers.dart';
+
+class PodcastListItem extends StatelessWidget {
+  const PodcastListItem({
+    super.key,
+    required this.podcast,
+    this.onTap,
+    this.onSubscribeToggle,
+    this.trailing,
+  });
+
+  final Podcast podcast;
+  final VoidCallback? onTap;
+  final VoidCallback? onSubscribeToggle;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final coverImage = podcast.coverImageUrl.isNotEmpty
+        ? Image.network(
+            podcast.coverImageUrl,
+            width: 72,
+            height: 72,
+            fit: BoxFit.cover,
+          )
+        : Container(
+            width: 72,
+            height: 72,
+            color: colorScheme.surfaceVariant,
+            child: Icon(Icons.podcasts, color: colorScheme.primary),
+          );
+
+    return Card(
+      elevation: kCardElevation,
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(kSmallPadding),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: coverImage,
+              ),
+              const SizedBox(width: kSmallPadding),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      podcast.title,
+                      style: theme.textTheme.titleMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      ellipsize(podcast.description, maxLength: 110),
+                      style: theme.textTheme.bodySmall,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '${podcast.category} · ${podcast.episodeCount} epizód',
+                      style: kSecondaryTextStyle.copyWith(
+                        color: theme.textTheme.bodySmall?.color,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: kSmallPadding),
+              trailing ??
+                  IconButton(
+                    onPressed: onSubscribeToggle,
+                    icon: Icon(
+                      podcast.isSubscribed
+                          ? Icons.favorite
+                          : Icons.favorite_border,
+                    ),
+                    tooltip: podcast.isSubscribed
+                        ? 'Leiratkozás'
+                        : 'Feliratkozás',
+                  ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/services/api_service.dart
+++ b/klubradio_archivum/lib/services/api_service.dart
@@ -1,0 +1,361 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/episode.dart';
+import '../models/podcast.dart';
+import '../models/show_host.dart';
+
+class ApiException implements Exception {
+  ApiException(this.message, [this.statusCode]);
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() =>
+      'ApiException(statusCode: $statusCode, message: $message)';
+}
+
+class ApiService {
+  ApiService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  // TODO: Replace with the actual Supabase REST endpoint for the project.
+  static const String _supabaseUrl =
+      'https://your-supabase-project.supabase.co';
+
+  // TODO: Replace with the project's Supabase anon/public API key.
+  static const String _supabaseAnonKey = 'supabase-anon-key';
+
+  static const String _podcastTable = 'podcasts';
+  static const String _episodeTable = 'episodes';
+
+  bool get _usingPlaceholderCredentials =>
+      _supabaseUrl.contains('your-supabase-project') ||
+      _supabaseAnonKey == 'supabase-anon-key';
+
+  Map<String, String> get _headers => <String, String>{
+        'Content-Type': 'application/json',
+        'apikey': _supabaseAnonKey,
+        'Authorization': 'Bearer $_supabaseAnonKey',
+        'Accept': 'application/json',
+      };
+
+  Future<List<Podcast>> fetchFeaturedPodcasts() async {
+    if (_usingPlaceholderCredentials) {
+      return _mockPodcasts.take(5).toList();
+    }
+
+    final uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/$_podcastTable?select=*&is_featured=eq.true&order=updated_at.desc.nullslast',
+    );
+    final response = await _client.get(uri, headers: _headers);
+    return _parsePodcastResponse(response);
+  }
+
+  Future<List<Podcast>> fetchTrendingPodcasts() async {
+    if (_usingPlaceholderCredentials) {
+      return _mockPodcasts
+          .skip(1)
+          .take(5)
+          .map((podcast) => podcast.copyWith())
+          .toList();
+    }
+
+    final uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/$_podcastTable?select=*&order=weekly_listens.desc.nullslast&limit=10',
+    );
+    final response = await _client.get(uri, headers: _headers);
+    return _parsePodcastResponse(response);
+  }
+
+  Future<List<Podcast>> fetchRecommendedPodcasts() async {
+    if (_usingPlaceholderCredentials) {
+      return _mockPodcasts;
+    }
+
+    final uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/$_podcastTable?select=*&order=recommendation_score.desc.nullslast&limit=12',
+    );
+    final response = await _client.get(uri, headers: _headers);
+    return _parsePodcastResponse(response);
+  }
+
+  Future<List<String>> fetchTopCategories() async {
+    if (_usingPlaceholderCredentials) {
+      final categories = _mockPodcasts.map((podcast) => podcast.category).toSet();
+      return categories.toList();
+    }
+
+    final uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/$_podcastTable?select=category&order=category.asc',
+    );
+    final response = await _client.get(uri, headers: _headers);
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to fetch categories', response.statusCode);
+    }
+
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    final categories = decoded
+        .map((entry) => entry is Map<String, dynamic>
+            ? entry['category']?.toString()
+            : entry.toString())
+        .whereType<String>()
+        .toSet()
+        .toList();
+    categories.sort();
+    return categories;
+  }
+
+  Future<List<Episode>> fetchEpisodesForPodcast(String podcastId) async {
+    if (_usingPlaceholderCredentials) {
+      return _mockEpisodesByPodcast[podcastId]?.toList() ??
+          const <Episode>[];
+    }
+
+    final uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/$_episodeTable?select=*&podcast_id=eq.$podcastId&order=published_at.desc',
+    );
+    final response = await _client.get(uri, headers: _headers);
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to load episodes', response.statusCode);
+    }
+
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(Episode.fromJson)
+        .toList();
+  }
+
+  Future<List<Episode>> searchEpisodes(String query) async {
+    if (query.trim().isEmpty) {
+      return const <Episode>[];
+    }
+
+    if (_usingPlaceholderCredentials) {
+      final lower = query.toLowerCase();
+      return _mockEpisodesByPodcast.values
+          .expand((episodes) => episodes)
+          .where(
+            (episode) =>
+                episode.title.toLowerCase().contains(lower) ||
+                episode.description.toLowerCase().contains(lower),
+          )
+          .toList();
+    }
+
+    final encodedQuery = Uri.encodeComponent('%$query%');
+    final uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/$_episodeTable?select=*&or=(title.ilike.$encodedQuery,description.ilike.$encodedQuery)&order=published_at.desc&limit=25',
+    );
+    final response = await _client.get(uri, headers: _headers);
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to search episodes', response.statusCode);
+    }
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(Episode.fromJson)
+        .toList();
+  }
+
+  Future<void> dispose() async {
+    _client.close();
+  }
+
+  List<Podcast> _parsePodcastResponse(http.Response response) {
+    if (response.statusCode != 200) {
+      throw ApiException('Failed to fetch podcasts', response.statusCode);
+    }
+
+    final decoded = jsonDecode(response.body) as List<dynamic>;
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(Podcast.fromJson)
+        .toList();
+  }
+}
+
+final List<Podcast> _mockPodcasts = <Podcast>[
+  Podcast(
+    id: 'esti-gyors',
+    title: 'Esti gyors',
+    description:
+        'Hírműsor a Klubrádió archívumából: naprakész politikai és közéleti beszélgetések.',
+    category: 'Hírek',
+    coverImageUrl:
+        'https://images.klubradio.hu/archivum/esti-gyors.jpg',
+    language: 'hu',
+    hosts: const <ShowHost>[
+      ShowHost(
+        id: 'bolgar-gyorgy',
+        name: 'Bolgár György',
+        bio: 'Klubrádió műsorvezető és újságíró.',
+      ),
+    ],
+    episodeCount: 180,
+  ),
+  Podcast(
+    id: 'megbeszeljuk',
+    title: 'Megbeszéljük...!',
+    description:
+        'Bolgár György ikonikus műsora hallgatói betelefonálásokkal és közéleti elemzéssel.',
+    category: 'Közélet',
+    coverImageUrl:
+        'https://images.klubradio.hu/archivum/megbeszeljuk.jpg',
+    language: 'hu',
+    hosts: const <ShowHost>[
+      ShowHost(
+        id: 'bolgar-gyorgy',
+        name: 'Bolgár György',
+      ),
+    ],
+    episodeCount: 240,
+  ),
+  Podcast(
+    id: 'reggeli-gyors',
+    title: 'Reggeli gyors',
+    description:
+        'Reggeli hírműsor elemzésekkel, interjúkkal és friss tudósításokkal.',
+    category: 'Hírek',
+    coverImageUrl:
+        'https://images.klubradio.hu/archivum/reggeli-gyors.jpg',
+    language: 'hu',
+    hosts: const <ShowHost>[
+      ShowHost(
+        id: 'simon-andras',
+        name: 'Simon András',
+      ),
+    ],
+    episodeCount: 200,
+  ),
+  Podcast(
+    id: 'sport-hela',
+    title: 'Hosszabbítás',
+    description: 'Sportmagazin a legfrissebb hírekkel és interjúkkal.',
+    category: 'Sport',
+    coverImageUrl: 'https://images.klubradio.hu/archivum/hosszabbitas.jpg',
+    language: 'hu',
+    hosts: const <ShowHost>[
+      ShowHost(
+        id: 'sajo-ando',
+        name: 'Sajó Andor',
+      ),
+    ],
+    episodeCount: 120,
+  ),
+  Podcast(
+    id: 'szabad-sajto',
+    title: 'Szabad Sáv',
+    description: 'Kultúra és társadalom a Klubrádió archívumából.',
+    category: 'Kultúra',
+    coverImageUrl: 'https://images.klubradio.hu/archivum/szabad-sav.jpg',
+    language: 'hu',
+    hosts: const <ShowHost>[
+      ShowHost(
+        id: 'musorvezeto',
+        name: 'Klubrádió műsorvezetők',
+      ),
+    ],
+    episodeCount: 95,
+  ),
+];
+
+final Map<String, List<Episode>> _mockEpisodesByPodcast =
+    <String, List<Episode>>{
+  'esti-gyors': <Episode>[
+    Episode(
+      id: 'esti-gyors-2025-09-16',
+      podcastId: 'esti-gyors',
+      title: 'Esti gyors - 2025. szeptember 16.',
+      description:
+          'Az esti műsor legfontosabb közéleti témái a Klubrádió archívumából.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/esti-gyors-2025-09-16.mp3',
+      duration: const Duration(minutes: 52, seconds: 18),
+      publishedAt: DateTime(2025, 9, 16, 18, 30),
+      imageUrl: 'https://images.klubradio.hu/archivum/esti-gyors.jpg',
+    ),
+    Episode(
+      id: 'esti-gyors-2025-09-15',
+      podcastId: 'esti-gyors',
+      title: 'Esti gyors - 2025. szeptember 15.',
+      description:
+          'Napi összefoglaló gazdasági és politikai fókuszban a Klubrádióban.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/esti-gyors-2025-09-15.mp3',
+      duration: const Duration(minutes: 49, seconds: 10),
+      publishedAt: DateTime(2025, 9, 15, 18, 30),
+      imageUrl: 'https://images.klubradio.hu/archivum/esti-gyors.jpg',
+    ),
+  ],
+  'megbeszeljuk': <Episode>[
+    Episode(
+      id: 'megbeszeljuk-2025-09-16',
+      podcastId: 'megbeszeljuk',
+      title: 'Megbeszéljük...! - 2025. szeptember 16.',
+      description:
+          'Bolgár György és a hallgatók beszélgetése a legfontosabb hírekről.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/megbeszeljuk-2025-09-16.mp3',
+      duration: const Duration(minutes: 58, seconds: 2),
+      publishedAt: DateTime(2025, 9, 16, 15, 5),
+      imageUrl: 'https://images.klubradio.hu/archivum/megbeszeljuk.jpg',
+    ),
+    Episode(
+      id: 'megbeszeljuk-2025-09-15',
+      podcastId: 'megbeszeljuk',
+      title: 'Megbeszéljük...! - 2025. szeptember 15.',
+      description: 'Hallgatói betelefonálások és elemzések a Klubrádióból.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/megbeszeljuk-2025-09-15.mp3',
+      duration: const Duration(minutes: 54, seconds: 30),
+      publishedAt: DateTime(2025, 9, 15, 15, 5),
+      imageUrl: 'https://images.klubradio.hu/archivum/megbeszeljuk.jpg',
+    ),
+  ],
+  'reggeli-gyors': <Episode>[
+    Episode(
+      id: 'reggeli-gyors-2025-09-16',
+      podcastId: 'reggeli-gyors',
+      title: 'Reggeli gyors - 2025. szeptember 16.',
+      description:
+          'Reggeli műsor friss politikai és gazdasági témákkal.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/reggeli-gyors-2025-09-16.mp3',
+      duration: const Duration(minutes: 45, seconds: 44),
+      publishedAt: DateTime(2025, 9, 16, 7, 5),
+      imageUrl: 'https://images.klubradio.hu/archivum/reggeli-gyors.jpg',
+    ),
+  ],
+  'sport-hela': <Episode>[
+    Episode(
+      id: 'sport-hela-2025-09-16',
+      podcastId: 'sport-hela',
+      title: 'Hosszabbítás - 2025. szeptember 16.',
+      description: 'Heti sportösszefoglaló interjúkkal a Klubrádióból.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/hosszabbitas-2025-09-16.mp3',
+      duration: const Duration(minutes: 43, seconds: 12),
+      publishedAt: DateTime(2025, 9, 16, 20),
+      imageUrl: 'https://images.klubradio.hu/archivum/hosszabbitas.jpg',
+    ),
+  ],
+  'szabad-sajto': <Episode>[
+    Episode(
+      id: 'szabad-sav-2025-09-15',
+      podcastId: 'szabad-sajto',
+      title: 'Szabad Sáv - 2025. szeptember 15.',
+      description:
+          'Kultúra, társadalom, művészet a Klubrádió archívumában.',
+      audioUrl:
+          'https://cdn.klubradio.hu/audio/szabad-sav-2025-09-15.mp3',
+      duration: const Duration(minutes: 38, seconds: 27),
+      publishedAt: DateTime(2025, 9, 15, 19, 30),
+      imageUrl: 'https://images.klubradio.hu/archivum/szabad-sav.jpg',
+    ),
+  ],
+};

--- a/klubradio_archivum/lib/services/audio_player_service.dart
+++ b/klubradio_archivum/lib/services/audio_player_service.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:just_audio/just_audio.dart';
+
+import '../models/episode.dart';
+
+class AudioPlayerService {
+  AudioPlayerService() : _player = AudioPlayer();
+
+  final AudioPlayer _player;
+  Episode? _currentEpisode;
+
+  Episode? get currentEpisode => _currentEpisode;
+
+  Stream<Duration?> get durationStream => _player.durationStream;
+  Stream<Duration> get positionStream => _player.positionStream;
+  Stream<Duration> get bufferedPositionStream => _player.bufferedPositionStream;
+  Stream<PlayerState> get playerStateStream => _player.playerStateStream;
+
+  Future<void> setEpisode(Episode episode) async {
+    if (_currentEpisode?.id == episode.id) {
+      return;
+    }
+
+    _currentEpisode = episode;
+
+    if (episode.localFilePath != null && episode.localFilePath!.isNotEmpty) {
+      final file = File(episode.localFilePath!);
+      if (await file.exists()) {
+        await _player.setFilePath(episode.localFilePath!);
+        return;
+      }
+    }
+
+    if (episode.audioUrl.isNotEmpty) {
+      await _player.setUrl(episode.audioUrl);
+    }
+  }
+
+  Future<void> play() => _player.play();
+
+  Future<void> pause() => _player.pause();
+
+  Future<void> stop() => _player.stop();
+
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  Future<void> seekToStart() => _player.seek(Duration.zero);
+
+  Future<void> playEpisode(Episode episode) async {
+    await setEpisode(episode);
+    await play();
+  }
+
+  Future<void> dispose() async {
+    await _player.dispose();
+  }
+}

--- a/klubradio_archivum/lib/services/download_service.dart
+++ b/klubradio_archivum/lib/services/download_service.dart
@@ -1,0 +1,87 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/episode.dart';
+
+typedef DownloadProgressCallback = void Function(
+    int receivedBytes, int totalBytes);
+
+class DownloadException implements Exception {
+  DownloadException(this.message, [this.statusCode]);
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'DownloadException($message, statusCode: $statusCode)';
+}
+
+class DownloadService {
+  DownloadService({http.Client? client})
+      : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  Future<String> downloadEpisode(
+    Episode episode, {
+    DownloadProgressCallback? onProgress,
+  }) async {
+    if (episode.audioUrl.isEmpty) {
+      throw DownloadException('Missing audio URL for ${episode.title}');
+    }
+
+    final uri = Uri.parse(episode.audioUrl);
+    final request = http.Request('GET', uri);
+    final response = await _client.send(request);
+
+    if (response.statusCode != 200) {
+      throw DownloadException(
+        'Failed to download episode ${episode.id}',
+        response.statusCode,
+      );
+    }
+
+    final directory = await getApplicationDocumentsDirectory();
+    final downloadDirectory = Directory('${directory.path}/downloads');
+    if (!await downloadDirectory.exists()) {
+      await downloadDirectory.create(recursive: true);
+    }
+
+    final sanitizedId = episode.id.replaceAll(RegExp(r'[^a-zA-Z0-9_-]'), '_');
+    final filePath = '${downloadDirectory.path}/$sanitizedId.mp3';
+    final file = File(filePath);
+    final sink = file.openWrite();
+
+    int receivedBytes = 0;
+    final totalBytes = response.contentLength ?? 0;
+
+    await for (final chunk in response.stream) {
+      receivedBytes += chunk.length;
+      sink.add(chunk);
+      onProgress?.call(receivedBytes, totalBytes);
+    }
+
+    await sink.flush();
+    await sink.close();
+
+    return filePath;
+  }
+
+  Future<void> deleteDownloadedFile(String filePath) async {
+    if (filePath.isEmpty) {
+      return;
+    }
+
+    final file = File(filePath);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  Future<void> dispose() async {
+    _client.close();
+  }
+}


### PR DESCRIPTION
## Summary
- replace the boilerplate entry point with a multi-provider MaterialApp, bottom navigation scaffold, and core routes
- add data models, Supabase-aware services with mock fallbacks, and state providers for podcasts, episodes, and theme handling
- implement feature screens (home, discover, downloads, now playing, search, settings, profile, about) plus reusable widgets and utilities for playback, downloads, and UI elements

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf1bbcd82c832ba4a95c501eeaf181