### PR TITLE
Implement Flutter app structure for development phase

### DIFF
--- a/klubradio_archivum/lib/main.dart
+++ b/klubradio_archivum/lib/main.dart
@@ -1,122 +1,103 @@
 import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:provider/provider.dart';
 
-void main() {
-  runApp(const MyApp());
+import 'providers/episode.provider.dart';
+import 'providers/podcast_provider.dart';
+import 'providers/theme_provider.dart';
+import 'screens/home_screen/home_screen.dart';
+import 'services/api_service.dart';
+import 'services/audio_player_service.dart';
+import 'services/download_service.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  runApp(const KlubradioArchivumApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class KlubradioArchivumApp extends StatelessWidget {
+  const KlubradioArchivumApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+    return MultiProvider(
+      providers: [
+        Provider<ApiService>(
+          create: (_) => ApiService(),
+          dispose: (_, ApiService service) => service.dispose(),
         ),
+        Provider<DownloadService>(
+          create: (_) => DownloadService(),
+          dispose: (_, DownloadService service) => service.dispose(),
+        ),
+        Provider<AudioPlayerService>(
+          create: (_) => AudioPlayerService(),
+          dispose: (_, AudioPlayerService service) => service.dispose(),
+        ),
+        ChangeNotifierProvider<ThemeProvider>(
+          create: (_) => ThemeProvider(),
+        ),
+        ChangeNotifierProxyProvider2<ApiService, DownloadService,
+            PodcastProvider>(
+          create: (BuildContext context) => PodcastProvider(
+            apiService: context.read<ApiService>(),
+            downloadService: context.read<DownloadService>(),
+          ),
+          update: (
+            BuildContext context,
+            ApiService apiService,
+            DownloadService downloadService,
+            PodcastProvider? previous,
+          ) {
+            if (previous != null) {
+              previous.updateDependencies(apiService, downloadService);
+              return previous;
+            }
+            return PodcastProvider(
+              apiService: apiService,
+              downloadService: downloadService,
+            );
+          },
+        ),
+        ChangeNotifierProxyProvider2<ApiService, AudioPlayerService,
+            EpisodeProvider>(
+          create: (BuildContext context) => EpisodeProvider(
+            apiService: context.read<ApiService>(),
+            audioPlayerService: context.read<AudioPlayerService>(),
+          ),
+          update: (
+            BuildContext context,
+            ApiService apiService,
+            AudioPlayerService audioPlayerService,
+            EpisodeProvider? previous,
+          ) {
+            if (previous != null) {
+              previous.updateDependencies(apiService, audioPlayerService);
+              return previous;
+            }
+            return EpisodeProvider(
+              apiService: apiService,
+              audioPlayerService: audioPlayerService,
+            );
+          },
+        ),
+      ],
+      child: Consumer<ThemeProvider>(
+        builder: (
+          BuildContext context,
+          ThemeProvider themeProvider,
+          Widget? child,
+        ) {
+          return MaterialApp(
+            title: 'Klubrádió Archívum',
+            theme: themeProvider.lightTheme,
+            darkTheme: themeProvider.darkTheme,
+            themeMode: themeProvider.themeMode,
+            home: const HomeScreen(),
+          );
+        },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add_rounded),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/klubradio_archivum/lib/models/episode.dart
+++ b/klubradio_archivum/lib/models/episode.dart
@@ -1,0 +1,142 @@
+import 'dart:convert';
+
+enum DownloadStatus { notDownloaded, queued, downloading, downloaded, failed }
+
+class Episode {
+  Episode({
+    required this.id,
+    required this.podcastId,
+    required this.title,
+    required this.description,
+    required this.audioUrl,
+    required this.publishedAt,
+    required this.duration,
+    this.imageUrl,
+    this.hosts = const <String>[],
+    this.isFavourite = false,
+    this.downloadStatus = DownloadStatus.notDownloaded,
+    this.downloadProgress = 0,
+    this.localFilePath,
+  });
+
+  factory Episode.fromJson(Map<String, dynamic> json) {
+    final hostsJson = json['hosts'];
+    return Episode(
+      id: json['id'].toString(),
+      podcastId: json['podcastId'].toString(),
+      title: json['title'] as String? ?? '',
+      description: json['description'] as String? ?? '',
+      audioUrl: json['audioUrl'] as String? ?? '',
+      publishedAt: json['publishedAt'] != null
+          ? DateTime.tryParse(json['publishedAt'].toString()) ?? DateTime.now()
+          : DateTime.now(),
+      duration: json['duration'] is int
+          ? Duration(seconds: json['duration'] as int)
+          : _durationFromString(json['duration']?.toString()),
+      imageUrl: json['imageUrl'] as String?,
+      hosts: hostsJson is List
+          ? hostsJson.map((dynamic e) => e.toString()).toList()
+          : const <String>[],
+      isFavourite: json['isFavourite'] as bool? ?? false,
+      downloadStatus: _downloadStatusFromJson(json['downloadStatus']),
+      downloadProgress: (json['downloadProgress'] as num?)?.toDouble() ?? 0,
+      localFilePath: json['localFilePath'] as String?,
+    );
+  }
+
+  final String id;
+  final String podcastId;
+  final String title;
+  final String description;
+  final String audioUrl;
+  final DateTime publishedAt;
+  final Duration duration;
+  final String? imageUrl;
+  final List<String> hosts;
+  final bool isFavourite;
+  final DownloadStatus downloadStatus;
+  final double downloadProgress;
+  final String? localFilePath;
+
+  Episode copyWith({
+    String? id,
+    String? podcastId,
+    String? title,
+    String? description,
+    String? audioUrl,
+    DateTime? publishedAt,
+    Duration? duration,
+    String? imageUrl,
+    List<String>? hosts,
+    bool? isFavourite,
+    DownloadStatus? downloadStatus,
+    double? downloadProgress,
+    String? localFilePath,
+  }) {
+    return Episode(
+      id: id ?? this.id,
+      podcastId: podcastId ?? this.podcastId,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      audioUrl: audioUrl ?? this.audioUrl,
+      publishedAt: publishedAt ?? this.publishedAt,
+      duration: duration ?? this.duration,
+      imageUrl: imageUrl ?? this.imageUrl,
+      hosts: hosts ?? List<String>.from(this.hosts),
+      isFavourite: isFavourite ?? this.isFavourite,
+      downloadStatus: downloadStatus ?? this.downloadStatus,
+      downloadProgress: downloadProgress ?? this.downloadProgress,
+      localFilePath: localFilePath ?? this.localFilePath,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'podcastId': podcastId,
+      'title': title,
+      'description': description,
+      'audioUrl': audioUrl,
+      'publishedAt': publishedAt.toIso8601String(),
+      'duration': duration.inSeconds,
+      'imageUrl': imageUrl,
+      'hosts': hosts,
+      'isFavourite': isFavourite,
+      'downloadStatus': downloadStatus.name,
+      'downloadProgress': downloadProgress,
+      'localFilePath': localFilePath,
+    };
+  }
+
+  static Duration _durationFromString(String? value) {
+    if (value == null || value.isEmpty) {
+      return Duration.zero;
+    }
+    final parts = value.split(':');
+    if (parts.length == 3) {
+      final hours = int.tryParse(parts[0]) ?? 0;
+      final minutes = int.tryParse(parts[1]) ?? 0;
+      final seconds = int.tryParse(parts[2]) ?? 0;
+      return Duration(hours: hours, minutes: minutes, seconds: seconds);
+    }
+    if (parts.length == 2) {
+      final minutes = int.tryParse(parts[0]) ?? 0;
+      final seconds = int.tryParse(parts[1]) ?? 0;
+      return Duration(minutes: minutes, seconds: seconds);
+    }
+    return Duration(seconds: int.tryParse(value) ?? 0);
+  }
+
+  static DownloadStatus _downloadStatusFromJson(dynamic value) {
+    if (value == null) {
+      return DownloadStatus.notDownloaded;
+    }
+    return DownloadStatus.values.firstWhere(
+      (DownloadStatus status) => status.name == value.toString(),
+      orElse: () => DownloadStatus.notDownloaded,
+    );
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/klubradio_archivum/lib/models/podcast.dart
+++ b/klubradio_archivum/lib/models/podcast.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'episode.dart';
+import 'show_host.dart';
+
+/// Represents a podcast or show within the Klubrádió archive.
+class Podcast {
+  Podcast({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.categories,
+    required this.coverImageUrl,
+    required this.language,
+    required this.episodeCount,
+    required this.hosts,
+    this.latestEpisode,
+    this.lastUpdated,
+    this.isSubscribed = false,
+    this.isTrending = false,
+    this.isRecommended = false,
+  });
+
+  factory Podcast.fromJson(Map<String, dynamic> json) {
+    final hostsJson = json['hosts'];
+    final categoriesJson = json['categories'];
+    return Podcast(
+      id: json['id'].toString(),
+      title: json['title'] as String? ?? 'Ismeretlen műsor',
+      description: json['description'] as String? ?? '',
+      categories: categoriesJson is List
+          ? categoriesJson.map((dynamic e) => e.toString()).toList()
+          : const <String>[],
+      coverImageUrl: json['coverImageUrl'] as String? ?? '',
+      language: json['language'] as String? ?? 'hu',
+      episodeCount: json['episodeCount'] is int
+          ? json['episodeCount'] as int
+          : int.tryParse(json['episodeCount']?.toString() ?? '') ?? 0,
+      hosts: hostsJson is List
+          ? hostsJson
+              .whereType<Map<String, dynamic>>()
+              .map(ShowHost.fromJson)
+              .toList()
+          : const <ShowHost>[],
+      latestEpisode: json['latestEpisode'] is Map<String, dynamic>
+          ? Episode.fromJson(json['latestEpisode'] as Map<String, dynamic>)
+          : null,
+      lastUpdated: json['lastUpdated'] != null
+          ? DateTime.tryParse(json['lastUpdated'].toString())
+          : null,
+      isSubscribed: json['isSubscribed'] as bool? ?? false,
+      isTrending: json['isTrending'] as bool? ?? false,
+      isRecommended: json['isRecommended'] as bool? ?? false,
+    );
+  }
+
+  final String id;
+  final String title;
+  final String description;
+  final List<String> categories;
+  final String coverImageUrl;
+  final String language;
+  final int episodeCount;
+  final List<ShowHost> hosts;
+  final Episode? latestEpisode;
+  final DateTime? lastUpdated;
+  final bool isSubscribed;
+  final bool isTrending;
+  final bool isRecommended;
+
+  Podcast copyWith({
+    String? id,
+    String? title,
+    String? description,
+    List<String>? categories,
+    String? coverImageUrl,
+    String? language,
+    int? episodeCount,
+    List<ShowHost>? hosts,
+    Episode? latestEpisode,
+    DateTime? lastUpdated,
+    bool? isSubscribed,
+    bool? isTrending,
+    bool? isRecommended,
+  }) {
+    return Podcast(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      categories: categories ?? List<String>.from(this.categories),
+      coverImageUrl: coverImageUrl ?? this.coverImageUrl,
+      language: language ?? this.language,
+      episodeCount: episodeCount ?? this.episodeCount,
+      hosts: hosts ?? List<ShowHost>.from(this.hosts),
+      latestEpisode: latestEpisode ?? this.latestEpisode,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+      isSubscribed: isSubscribed ?? this.isSubscribed,
+      isTrending: isTrending ?? this.isTrending,
+      isRecommended: isRecommended ?? this.isRecommended,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'title': title,
+      'description': description,
+      'categories': categories,
+      'coverImageUrl': coverImageUrl,
+      'language': language,
+      'episodeCount': episodeCount,
+      'hosts': hosts.map((ShowHost host) => host.toJson()).toList(),
+      'latestEpisode': latestEpisode?.toJson(),
+      'lastUpdated': lastUpdated?.toIso8601String(),
+      'isSubscribed': isSubscribed,
+      'isTrending': isTrending,
+      'isRecommended': isRecommended,
+    };
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/klubradio_archivum/lib/models/show_host.dart
+++ b/klubradio_archivum/lib/models/show_host.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+class ShowHost {
+  const ShowHost({
+    required this.id,
+    required this.name,
+    this.bio,
+    this.avatarUrl,
+    this.socialLinks = const <String, String>{},
+  });
+
+  factory ShowHost.fromJson(Map<String, dynamic> json) {
+    final social = json['socialLinks'];
+    return ShowHost(
+      id: json['id'].toString(),
+      name: json['name'] as String? ?? 'Ismeretlen műsorvezető',
+      bio: json['bio'] as String?,
+      avatarUrl: json['avatarUrl'] as String?,
+      socialLinks: social is Map
+          ? social.map(
+              (dynamic key, dynamic value) =>
+                  MapEntry(key.toString(), value.toString()),
+            )
+          : const <String, String>{},
+    );
+  }
+
+  final String id;
+  final String name;
+  final String? bio;
+  final String? avatarUrl;
+  final Map<String, String> socialLinks;
+
+  ShowHost copyWith({
+    String? id,
+    String? name,
+    String? bio,
+    String? avatarUrl,
+    Map<String, String>? socialLinks,
+  }) {
+    return ShowHost(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      bio: bio ?? this.bio,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      socialLinks: socialLinks ?? Map<String, String>.from(this.socialLinks),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'name': name,
+      'bio': bio,
+      'avatarUrl': avatarUrl,
+      'socialLinks': socialLinks,
+    };
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/klubradio_archivum/lib/models/user_profile.dart
+++ b/klubradio_archivum/lib/models/user_profile.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'episode.dart';
+
+class UserProfile {
+  UserProfile({
+    required this.id,
+    required this.displayName,
+    this.email,
+    this.avatarUrl,
+    this.languageCode = 'hu',
+    this.playbackSpeed = 1.0,
+    this.maxAutoDownload = 5,
+    this.subscribedPodcastIds = const <String>{},
+    this.recentlyPlayed = const <Episode>[],
+    this.favouriteEpisodeIds = const <String>{},
+  });
+
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    final subscribed = json['subscribedPodcastIds'];
+    final favourites = json['favouriteEpisodeIds'];
+    final recentlyPlayedJson = json['recentlyPlayed'];
+    return UserProfile(
+      id: json['id'].toString(),
+      displayName: json['displayName'] as String? ?? 'Hallgató',
+      email: json['email'] as String?,
+      avatarUrl: json['avatarUrl'] as String?,
+      languageCode: json['languageCode'] as String? ?? 'hu',
+      playbackSpeed: (json['playbackSpeed'] as num?)?.toDouble() ?? 1.0,
+      maxAutoDownload: json['maxAutoDownload'] as int? ?? 5,
+      subscribedPodcastIds: subscribed is List
+          ? subscribed.map((dynamic id) => id.toString()).toSet()
+          : const <String>{},
+      recentlyPlayed: recentlyPlayedJson is List
+          ? recentlyPlayedJson
+              .whereType<Map<String, dynamic>>()
+              .map(Episode.fromJson)
+              .toList()
+          : const <Episode>[],
+      favouriteEpisodeIds: favourites is List
+          ? favourites.map((dynamic id) => id.toString()).toSet()
+          : const <String>{},
+    );
+  }
+
+  final String id;
+  final String displayName;
+  final String? email;
+  final String? avatarUrl;
+  final String languageCode;
+  final double playbackSpeed;
+  final int maxAutoDownload;
+  final Set<String> subscribedPodcastIds;
+  final List<Episode> recentlyPlayed;
+  final Set<String> favouriteEpisodeIds;
+
+  UserProfile copyWith({
+    String? id,
+    String? displayName,
+    String? email,
+    String? avatarUrl,
+    String? languageCode,
+    double? playbackSpeed,
+    int? maxAutoDownload,
+    Set<String>? subscribedPodcastIds,
+    List<Episode>? recentlyPlayed,
+    Set<String>? favouriteEpisodeIds,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      displayName: displayName ?? this.displayName,
+      email: email ?? this.email,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      languageCode: languageCode ?? this.languageCode,
+      playbackSpeed: playbackSpeed ?? this.playbackSpeed,
+      maxAutoDownload: maxAutoDownload ?? this.maxAutoDownload,
+      subscribedPodcastIds:
+          subscribedPodcastIds ?? Set<String>.from(this.subscribedPodcastIds),
+      recentlyPlayed: recentlyPlayed ?? List<Episode>.from(this.recentlyPlayed),
+      favouriteEpisodeIds:
+          favouriteEpisodeIds ?? Set<String>.from(this.favouriteEpisodeIds),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'displayName': displayName,
+      'email': email,
+      'avatarUrl': avatarUrl,
+      'languageCode': languageCode,
+      'playbackSpeed': playbackSpeed,
+      'maxAutoDownload': maxAutoDownload,
+      'subscribedPodcastIds': subscribedPodcastIds.toList(),
+      'recentlyPlayed': recentlyPlayed.map((Episode e) => e.toJson()).toList(),
+      'favouriteEpisodeIds': favouriteEpisodeIds.toList(),
+    };
+  }
+
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/klubradio_archivum/lib/providers/episode.provider.dart
+++ b/klubradio_archivum/lib/providers/episode.provider.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:just_audio/just_audio.dart';
+
+import '../models/episode.dart';
+import '../services/api_service.dart';
+import '../services/audio_player_service.dart';
+
+class EpisodeProvider extends ChangeNotifier {
+  EpisodeProvider({
+    required ApiService apiService,
+    required AudioPlayerService audioPlayerService,
+  })  : _apiService = apiService,
+        _audioPlayerService = audioPlayerService {
+    _positionSubscription =
+        _audioPlayerService.positionStream.listen(_onPositionChanged);
+    _playerStateSubscription =
+        _audioPlayerService.playerStateStream.listen(_onPlayerStateChanged);
+    _bufferingSubscription =
+        _audioPlayerService.bufferingStream.listen(_onBufferingChanged);
+  }
+
+  ApiService _apiService;
+  AudioPlayerService _audioPlayerService;
+
+  StreamSubscription<Duration>? _positionSubscription;
+  StreamSubscription<PlayerState>? _playerStateSubscription;
+  StreamSubscription<bool>? _bufferingSubscription;
+
+  Episode? _currentEpisode;
+  List<Episode> _queue = <Episode>[];
+  Duration _currentPosition = Duration.zero;
+  bool _isBuffering = false;
+  double _playbackSpeed = 1.0;
+
+  Episode? get currentEpisode => _currentEpisode;
+  Duration get currentPosition => _currentPosition;
+  bool get isPlaying => _audioPlayerService.isPlaying;
+  bool get isBuffering => _isBuffering;
+  Duration? get totalDuration => _audioPlayerService.totalDuration;
+  List<Episode> get queue => List<Episode>.unmodifiable(_queue);
+  double get playbackSpeed => _playbackSpeed;
+
+  void updateDependencies(
+    ApiService apiService,
+    AudioPlayerService audioPlayerService,
+  ) {
+    if (!identical(_apiService, apiService)) {
+      _apiService = apiService;
+    }
+    if (!identical(_audioPlayerService, audioPlayerService)) {
+      _positionSubscription?.cancel();
+      _playerStateSubscription?.cancel();
+      _bufferingSubscription?.cancel();
+      _audioPlayerService = audioPlayerService;
+      _positionSubscription =
+          _audioPlayerService.positionStream.listen(_onPositionChanged);
+      _playerStateSubscription =
+          _audioPlayerService.playerStateStream.listen(_onPlayerStateChanged);
+      _bufferingSubscription =
+          _audioPlayerService.bufferingStream.listen(_onBufferingChanged);
+    }
+  }
+
+  Future<List<Episode>> fetchEpisodes(String podcastId) async {
+    return _apiService.fetchEpisodesForPodcast(podcastId);
+  }
+
+  Future<void> playEpisode(Episode episode, {List<Episode>? queue}) async {
+    _currentEpisode = episode;
+    if (queue != null) {
+      _queue = queue;
+    } else if (!_queue.any((Episode item) => item.id == episode.id)) {
+      _queue.insert(0, episode);
+    }
+    await _audioPlayerService.loadEpisode(episode);
+    notifyListeners();
+  }
+
+  Future<void> playNext() async {
+    final Episode? nextEpisode = getNextEpisode();
+    if (nextEpisode != null) {
+      await playEpisode(nextEpisode);
+    }
+  }
+
+  Future<void> playPrevious() async {
+    final Episode? previousEpisode = getPreviousEpisode();
+    if (previousEpisode != null) {
+      await playEpisode(previousEpisode);
+    }
+  }
+
+  Episode? getNextEpisode() {
+    if (_currentEpisode == null) {
+      return null;
+    }
+    final int index =
+        _queue.indexWhere((Episode episode) => episode.id == _currentEpisode!.id);
+    if (index != -1 && index + 1 < _queue.length) {
+      return _queue[index + 1];
+    }
+    return null;
+  }
+
+  Episode? getPreviousEpisode() {
+    if (_currentEpisode == null) {
+      return null;
+    }
+    final int index =
+        _queue.indexWhere((Episode episode) => episode.id == _currentEpisode!.id);
+    if (index > 0) {
+      return _queue[index - 1];
+    }
+    return null;
+  }
+
+  Future<void> togglePlayPause() => _audioPlayerService.togglePlayPause();
+
+  Future<void> seek(Duration position) => _audioPlayerService.seek(position);
+
+  Future<void> updatePlaybackSpeed(double speed) async {
+    _playbackSpeed = speed;
+    await _audioPlayerService.setSpeed(speed);
+    notifyListeners();
+  }
+
+  void addToQueue(Episode episode) {
+    if (_queue.any((Episode item) => item.id == episode.id)) {
+      return;
+    }
+    _queue.add(episode);
+    notifyListeners();
+  }
+
+  void removeFromQueue(String episodeId) {
+    _queue.removeWhere((Episode episode) => episode.id == episodeId);
+    notifyListeners();
+  }
+
+  void _onPositionChanged(Duration position) {
+    _currentPosition = position;
+    notifyListeners();
+  }
+
+  void _onPlayerStateChanged(PlayerState state) {
+    notifyListeners();
+  }
+
+  void _onBufferingChanged(bool isBuffering) {
+    _isBuffering = isBuffering;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _positionSubscription?.cancel();
+    await _playerStateSubscription?.cancel();
+    await _bufferingSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/klubradio_archivum/lib/providers/podcast_provider.dart
+++ b/klubradio_archivum/lib/providers/podcast_provider.dart
@@ -1,0 +1,274 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../models/episode.dart';
+import '../models/podcast.dart';
+import '../models/user_profile.dart';
+import '../screens/utils/constants.dart' as constants;
+import '../services/api_service.dart';
+import '../services/download_service.dart';
+
+class PodcastProvider extends ChangeNotifier {
+  PodcastProvider({
+    required ApiService apiService,
+    required DownloadService downloadService,
+  })  : _apiService = apiService,
+        _downloadService = downloadService {
+    _downloadSubscription =
+        _downloadService.downloadStream.listen(_handleDownloadUpdate);
+  }
+
+  ApiService _apiService;
+  DownloadService _downloadService;
+  StreamSubscription<DownloadTask>? _downloadSubscription;
+
+  final Map<String, List<Episode>> _episodesByPodcast =
+      <String, List<Episode>>{};
+  final Map<String, DownloadTask> _downloads = <String, DownloadTask>{};
+  final List<String> _recentSearches = <String>[];
+
+  List<Podcast> _podcasts = <Podcast>[];
+  List<Podcast> _trendingPodcasts = <Podcast>[];
+  List<Podcast> _recommendedPodcasts = <Podcast>[];
+  List<Episode> _recentEpisodes = <Episode>[];
+
+  UserProfile? _userProfile;
+  bool _isLoading = false;
+  String? _errorMessage;
+  bool _initialised = false;
+
+  List<Podcast> get podcasts => _podcasts;
+  List<Podcast> get trendingPodcasts => _trendingPodcasts;
+  List<Podcast> get recommendedPodcasts => _recommendedPodcasts;
+  List<Episode> get recentEpisodes => _recentEpisodes;
+  UserProfile? get userProfile => _userProfile;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  List<String> get recentSearches => List<String>.unmodifiable(_recentSearches);
+  List<DownloadTask> get downloads => _downloads.values.toList();
+
+  List<Podcast> get subscribedPodcasts {
+    if (_userProfile == null) {
+      return const <Podcast>[];
+    }
+    return _podcasts
+        .where((Podcast podcast) =>
+            _userProfile!.subscribedPodcastIds.contains(podcast.id))
+        .toList();
+  }
+
+  void updateDependencies(
+    ApiService apiService,
+    DownloadService downloadService,
+  ) {
+    if (!identical(_apiService, apiService)) {
+      _apiService = apiService;
+    }
+    if (!identical(_downloadService, downloadService)) {
+      _downloadSubscription?.cancel();
+      _downloadService = downloadService;
+      _downloadSubscription =
+          _downloadService.downloadStream.listen(_handleDownloadUpdate);
+    }
+  }
+
+  Future<void> loadInitialData({bool forceRefresh = false}) async {
+    if (_isLoading) {
+      return;
+    }
+    if (_initialised && !forceRefresh) {
+      return;
+    }
+
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      final List<Podcast> fetchedPodcasts =
+          await _apiService.fetchLatestPodcasts();
+      final List<Podcast> trending =
+          await _apiService.fetchTrendingPodcasts();
+      final List<Podcast> recommended =
+          await _apiService.fetchRecommendedPodcasts();
+      final List<Episode> latestEpisodes =
+          await _apiService.fetchRecentEpisodes();
+
+      _podcasts = fetchedPodcasts;
+      _trendingPodcasts = trending;
+      _recommendedPodcasts = recommended;
+      _recentEpisodes = latestEpisodes;
+      _initialised = true;
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadUserProfile({String userId = constants.demoUserId}) async {
+    try {
+      _userProfile = await _apiService.fetchUserProfile(userId);
+      notifyListeners();
+    } catch (error) {
+      _errorMessage = error.toString();
+      notifyListeners();
+    }
+  }
+
+  Future<void> subscribe(String podcastId) async {
+    final UserProfile? profile = _userProfile;
+    if (profile == null) {
+      return;
+    }
+    if (!profile.subscribedPodcastIds.contains(podcastId)) {
+      _userProfile = profile.copyWith(
+        subscribedPodcastIds:
+            Set<String>.from(profile.subscribedPodcastIds)..add(podcastId),
+      );
+      _updatePodcastSubscription(podcastId, isSubscribed: true);
+      notifyListeners();
+      await _scheduleAutoDownloadForPodcast(podcastId);
+    }
+  }
+
+  Future<void> unsubscribe(String podcastId) async {
+    final UserProfile? profile = _userProfile;
+    if (profile == null) {
+      return;
+    }
+    if (profile.subscribedPodcastIds.contains(podcastId)) {
+      final Set<String> updated =
+          Set<String>.from(profile.subscribedPodcastIds)..remove(podcastId);
+      _userProfile = profile.copyWith(subscribedPodcastIds: updated);
+      _updatePodcastSubscription(podcastId, isSubscribed: false);
+      notifyListeners();
+    }
+  }
+
+  Future<void> downloadEpisode(Episode episode) async {
+    try {
+      await _downloadService.downloadEpisode(episode);
+    } catch (_) {
+      // Errors are surfaced via the download stream and UI indicators.
+    }
+  }
+
+  Future<void> removeDownload(String episodeId) async {
+    await _downloadService.removeDownload(episodeId);
+    _downloads.remove(episodeId);
+    notifyListeners();
+  }
+
+  Future<void> _scheduleAutoDownloadForPodcast(String podcastId) async {
+    final int maxDownloads =
+        _userProfile?.maxAutoDownload ?? constants.defaultAutoDownloadCount;
+    final List<Episode> episodes =
+        await _apiService.fetchEpisodesForPodcast(podcastId, limit: maxDownloads);
+    _episodesByPodcast[podcastId] = episodes;
+    for (final Episode episode in episodes.take(maxDownloads)) {
+      if (!_downloads.containsKey(episode.id)) {
+        unawaited(_downloadService.downloadEpisode(episode));
+      }
+    }
+    notifyListeners();
+  }
+
+  Future<List<Episode>> fetchEpisodesForPodcast(String podcastId) async {
+    List<Episode>? episodes = _episodesByPodcast[podcastId];
+    if (episodes == null || episodes.isEmpty) {
+      episodes = await _apiService.fetchEpisodesForPodcast(podcastId);
+      _episodesByPodcast[podcastId] = episodes;
+    }
+    return episodes;
+  }
+
+  void addRecentSearch(String query) {
+    final String trimmed = query.trim();
+    if (trimmed.isEmpty) {
+      return;
+    }
+    _recentSearches.remove(trimmed);
+    _recentSearches.insert(0, trimmed);
+    if (_recentSearches.length > constants.maxRecentSearches) {
+      _recentSearches.removeLast();
+    }
+    notifyListeners();
+  }
+
+  Future<List<Podcast>> searchPodcasts(String query) async {
+    addRecentSearch(query);
+    try {
+      return await _apiService.searchPodcasts(query);
+    } catch (error) {
+      _errorMessage = error.toString();
+      notifyListeners();
+      return const <Podcast>[];
+    }
+  }
+
+  void addRecentlyPlayed(Episode episode) {
+    final UserProfile? profile = _userProfile;
+    if (profile == null) {
+      return;
+    }
+    final List<Episode> updated = List<Episode>.from(profile.recentlyPlayed);
+    updated.removeWhere((Episode item) => item.id == episode.id);
+    updated.insert(0, episode);
+    if (updated.length > constants.maxRecentlyPlayed) {
+      updated.removeLast();
+    }
+    _userProfile = profile.copyWith(recentlyPlayed: updated);
+    notifyListeners();
+  }
+
+  void toggleFavourite(Episode episode) {
+    final UserProfile? profile = _userProfile;
+    if (profile == null) {
+      return;
+    }
+    final Set<String> favourites =
+        Set<String>.from(profile.favouriteEpisodeIds);
+    if (favourites.contains(episode.id)) {
+      favourites.remove(episode.id);
+    } else {
+      favourites.add(episode.id);
+    }
+    _userProfile = profile.copyWith(favouriteEpisodeIds: favourites);
+    notifyListeners();
+  }
+
+  void updateAutoDownloadCount(int count) {
+    final UserProfile? profile = _userProfile;
+    if (profile == null) {
+      return;
+    }
+    _userProfile = profile.copyWith(maxAutoDownload: count);
+    notifyListeners();
+  }
+
+  void _updatePodcastSubscription(String podcastId, {required bool isSubscribed}) {
+    _podcasts = _podcasts
+        .map(
+          (Podcast podcast) => podcast.id == podcastId
+              ? podcast.copyWith(isSubscribed: isSubscribed)
+              : podcast,
+        )
+        .toList();
+  }
+
+  void _handleDownloadUpdate(DownloadTask task) {
+    _downloads[task.episode.id] = task;
+    notifyListeners();
+  }
+
+  DownloadTask? getDownloadTask(String episodeId) => _downloads[episodeId];
+
+  @override
+  void dispose() {
+    _downloadSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/klubradio_archivum/lib/providers/theme_provider.dart
+++ b/klubradio_archivum/lib/providers/theme_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeProvider();
+
+  ThemeMode _themeMode = ThemeMode.system;
+
+  ThemeMode get themeMode => _themeMode;
+
+  ThemeData get lightTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFFB00020),
+          brightness: Brightness.light,
+        ),
+        useMaterial3: true,
+        fontFamily: 'Roboto',
+        scaffoldBackgroundColor: const Color(0xFFF6F6F6),
+        appBarTheme: const AppBarTheme(centerTitle: true),
+      );
+
+  ThemeData get darkTheme => ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFFCF6679),
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+        fontFamily: 'Roboto',
+      );
+
+  void toggleTheme(bool isDarkMode) {
+    _themeMode = isDarkMode ? ThemeMode.dark : ThemeMode.light;
+    notifyListeners();
+  }
+
+  void setThemeMode(ThemeMode mode) {
+    _themeMode = mode;
+    notifyListeners();
+  }
+}

--- a/klubradio_archivum/lib/screens/about_screen/about_screen.dart
+++ b/klubradio_archivum/lib/screens/about_screen/about_screen.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Az alkalmazásról')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: const <Widget>[
+            Text(
+              'Klubrádió archívum alkalmazás',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            SizedBox(height: 12),
+            Text(
+              'Az alkalmazás célja, hogy egyszerű hozzáférést biztosítson a Klubrádió '
+              'archív műsoraihoz, és lehetőséget adjon RSS feedek létrehozására '
+              'podcast lejátszók számára.',
+            ),
+            SizedBox(height: 12),
+            Text(
+              'Ez egy közösségi projekt, amely a Klubrádió támogatását szolgálja. '
+              'Minden tartalom szabadon elérhető a rádió hivatalos oldalán.',
+            ),
+            SizedBox(height: 12),
+            Text(
+              'Kapcsolat: info@klubradio.hu (tartalom), '
+              'TODO: developer@yourdomain.com (fejlesztői elérhetőség)',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/discover_screen.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/discover_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/podcast.dart';
+import '../../providers/podcast_provider.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+import 'recommended_podcasts_list.dart';
+import 'top_categories_list.dart';
+import 'trending_podcasts_list.dart';
+
+class DiscoverScreen extends StatelessWidget {
+  const DiscoverScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (BuildContext context, PodcastProvider provider, Widget? child) {
+        final List<Podcast> trending = provider.trendingPodcasts;
+        final List<Podcast> recommended = provider.recommendedPodcasts;
+
+        return RefreshIndicator(
+          onRefresh: () => provider.loadInitialData(forceRefresh: true),
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: <Widget>[
+              Text(
+                'Kiemelt kategóriák',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 8),
+              const TopCategoriesList(),
+              const SizedBox(height: 24),
+              Text(
+                'Ajánlott műsorok',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 12),
+              RecommendedPodcastsList(podcasts: recommended),
+              const SizedBox(height: 24),
+              Text(
+                'Felkapott',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 12),
+              TrendingPodcastsList(podcasts: trending),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/recommended_podcasts_list.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/recommended_podcasts_list.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../../models/podcast.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+
+class RecommendedPodcastsList extends StatelessWidget {
+  const RecommendedPodcastsList({super.key, required this.podcasts});
+
+  final List<Podcast> podcasts;
+
+  @override
+  Widget build(BuildContext context) {
+    if (podcasts.isEmpty) {
+      return Text(
+        'Nincs elérhető ajánlás. Frissítsd az adatokat később.',
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: podcasts.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (BuildContext context, int index) {
+        final Podcast podcast = podcasts[index];
+        return PodcastListItem(podcast: podcast);
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/top_categories_list.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/top_categories_list.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart' as constants;
+
+class TopCategoriesList extends StatelessWidget {
+  const TopCategoriesList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: constants.topCategories.map((String category) {
+        return FilterChip(
+          label: Text(category.toUpperCase()),
+          onSelected: (bool selected) {
+            if (!selected) {
+              return;
+            }
+            context.read<PodcastProvider>().addRecentSearch(category);
+            // TODO: trigger category specific filtering once API supports it.
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text('"$category" kategória kiválasztva.'),
+              ),
+            );
+          },
+        );
+      }).toList(),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/discover_screen/trending_podcasts_list.dart
+++ b/klubradio_archivum/lib/screens/discover_screen/trending_podcasts_list.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../../models/podcast.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+
+class TrendingPodcastsList extends StatelessWidget {
+  const TrendingPodcastsList({super.key, required this.podcasts});
+
+  final List<Podcast> podcasts;
+
+  @override
+  Widget build(BuildContext context) {
+    if (podcasts.isEmpty) {
+      return Text(
+        'Nincs felkapott műsor a listán.',
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: podcasts.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (BuildContext context, int index) {
+        final Podcast podcast = podcasts[index];
+        return PodcastListItem(podcast: podcast);
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/download_manager_screen/download_list.dart
+++ b/klubradio_archivum/lib/screens/download_manager_screen/download_list.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../../services/download_service.dart';
+import '../utils/helpers.dart';
+
+class DownloadList extends StatelessWidget {
+  const DownloadList({super.key, required this.downloads});
+
+  final List<DownloadTask> downloads;
+
+  @override
+  Widget build(BuildContext context) {
+    if (downloads.isEmpty) {
+      return Center(
+        child: Text(
+          'Nincsenek letöltött epizódok.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+
+    return ListView.separated(
+      itemCount: downloads.length,
+      separatorBuilder: (_, __) => const Divider(),
+      itemBuilder: (BuildContext context, int index) {
+        final DownloadTask task = downloads[index];
+        final statusLabel = formatDownloadStatus(task.status);
+        final progressLabel = formatProgress(task.progress);
+        return ListTile(
+          leading: Icon(_statusIcon(task.status)),
+          title: Text(task.episode.title),
+          subtitle: Text('$statusLabel • ${task.episode.podcastId}'),
+          trailing: _buildTrailing(context, task, progressLabel),
+        );
+      },
+    );
+  }
+
+  IconData _statusIcon(DownloadStatus status) {
+    switch (status) {
+      case DownloadStatus.downloading:
+        return Icons.downloading;
+      case DownloadStatus.downloaded:
+        return Icons.check_circle_outline;
+      case DownloadStatus.failed:
+        return Icons.error_outline;
+      case DownloadStatus.notDownloaded:
+        return Icons.download_outlined;
+      case DownloadStatus.queued:
+        return Icons.schedule;
+    }
+  }
+
+  Widget _buildTrailing(
+    BuildContext context,
+    DownloadTask task,
+    String progressLabel,
+  ) {
+    final PodcastProvider provider = context.read<PodcastProvider>();
+    switch (task.status) {
+      case DownloadStatus.downloading:
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(
+                value: task.progress,
+                strokeWidth: 3,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(progressLabel),
+          ],
+        );
+      case DownloadStatus.downloaded:
+        return IconButton(
+          icon: const Icon(Icons.delete_outline),
+          onPressed: () {
+            provider.removeDownload(task.episode.id);
+          },
+        );
+      case DownloadStatus.failed:
+        return IconButton(
+          icon: const Icon(Icons.refresh),
+          onPressed: () {
+            provider.downloadEpisode(task.episode);
+          },
+        );
+      case DownloadStatus.notDownloaded:
+      case DownloadStatus.queued:
+        return Text(progressLabel);
+    }
+  }
+}

--- a/klubradio_archivum/lib/screens/download_manager_screen/download_manager_screen.dart
+++ b/klubradio_archivum/lib/screens/download_manager_screen/download_manager_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import 'download_list.dart';
+
+class DownloadManagerScreen extends StatelessWidget {
+  const DownloadManagerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (
+        BuildContext context,
+        PodcastProvider provider,
+        Widget? child,
+      ) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Letöltéskezelő',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: DownloadList(downloads: provider.downloads),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/home_screen/home_screen.dart
+++ b/klubradio_archivum/lib/screens/home_screen/home_screen.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../models/podcast.dart';
+import '../../providers/episode.provider.dart';
+import '../../providers/podcast_provider.dart';
+import '../about_screen/about_screen.dart';
+import '../discover_screen/discover_screen.dart';
+import '../download_manager_screen/download_manager_screen.dart';
+import '../profile_screen/profile_screen.dart';
+import '../search_screen/search_screen.dart';
+import '../settings_screen/settings_screen.dart';
+import '../widgets/stateful/episode_list.dart';
+import '../widgets/stateful/now_playing_bar.dart';
+import '../widgets/stateless/bottom_navigation_bar.dart';
+import 'recently_played_list.dart';
+import 'subscribed_podcasts_list.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _currentIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final PodcastProvider podcastProvider = context.read<PodcastProvider>();
+      final EpisodeProvider episodeProvider = context.read<EpisodeProvider>();
+      await podcastProvider.loadInitialData();
+      await podcastProvider.loadUserProfile();
+      if (episodeProvider.currentEpisode == null &&
+          podcastProvider.recentEpisodes.isNotEmpty) {
+        // Preload the latest episode without autoplay to provide metadata for UI.
+        await episodeProvider.playEpisode(
+          podcastProvider.recentEpisodes.first,
+          queue: podcastProvider.recentEpisodes,
+        );
+        await episodeProvider.togglePlayPause();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final EpisodeProvider episodeProvider = context.watch<EpisodeProvider>();
+    final bool hasCurrentEpisode = episodeProvider.currentEpisode != null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Klubrádió Archívum'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (BuildContext context) => const AboutScreen(),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: IndexedStack(
+        index: _currentIndex,
+        children: <Widget>[
+          _buildHomeTab(context),
+          const DiscoverScreen(),
+          const SearchScreen(),
+          const DownloadManagerScreen(),
+          const ProfileScreen(),
+          const SettingsScreen(),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            if (hasCurrentEpisode) const NowPlayingBar(),
+            AppBottomNavigationBar(
+              currentIndex: _currentIndex,
+              onTap: (int index) {
+                setState(() {
+                  _currentIndex = index;
+                });
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHomeTab(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (BuildContext context, PodcastProvider provider, Widget? child) {
+        if (provider.isLoading && provider.podcasts.isEmpty) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (provider.errorMessage != null && provider.podcasts.isEmpty) {
+          return Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                provider.errorMessage!,
+                style: Theme.of(context).textTheme.bodyLarge,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          );
+        }
+
+        final List<Podcast> subscribed = provider.subscribedPodcasts;
+        final List<Episode> recentEpisodes = provider.recentEpisodes;
+        final List<Episode> recentlyPlayed =
+            provider.userProfile?.recentlyPlayed ?? const <Episode>[];
+
+        return RefreshIndicator(
+          onRefresh: () => provider.loadInitialData(forceRefresh: true),
+          child: ListView(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            children: <Widget>[
+              if (subscribed.isNotEmpty) ...<Widget>[
+                Text(
+                  'Feliratkozott műsorok',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 12),
+                SubscribedPodcastsList(podcasts: subscribed),
+                const SizedBox(height: 24),
+              ],
+              Text(
+                'Legutóbbi epizódok',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 12),
+              EpisodeList(episodes: recentEpisodes),
+              if (recentlyPlayed.isNotEmpty) ...<Widget>[
+                const SizedBox(height: 24),
+                Text(
+                  'Legutóbb hallgatott',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 12),
+                RecentlyPlayedList(episodes: recentlyPlayed),
+              ],
+              const SizedBox(height: 24),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/home_screen/recently_played_list.dart
+++ b/klubradio_archivum/lib/screens/home_screen/recently_played_list.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../providers/episode.provider.dart';
+import '../../providers/podcast_provider.dart';
+import '../utils/helpers.dart';
+
+class RecentlyPlayedList extends StatelessWidget {
+  const RecentlyPlayedList({super.key, required this.episodes});
+
+  final List<Episode> episodes;
+
+  @override
+  Widget build(BuildContext context) {
+    if (episodes.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SizedBox(
+      height: 160,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: episodes.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 12),
+        itemBuilder: (BuildContext context, int index) {
+          final Episode episode = episodes[index];
+          return _EpisodeCard(episode: episode);
+        },
+      ),
+    );
+  }
+}
+
+class _EpisodeCard extends StatelessWidget {
+  const _EpisodeCard({required this.episode});
+
+  final Episode episode;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return InkWell(
+      onTap: () async {
+        final EpisodeProvider episodeProvider =
+            context.read<EpisodeProvider>();
+        final PodcastProvider podcastProvider =
+            context.read<PodcastProvider>();
+        await episodeProvider.playEpisode(episode);
+        podcastProvider.addRecentlyPlayed(episode);
+      },
+      child: Container(
+        width: 220,
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              episode.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.titleMedium,
+            ),
+            const Spacer(),
+            Text(formatDuration(episode.duration)),
+            Text(
+              formatDate(episode.publishedAt),
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/home_screen/subscribed_podcasts_list.dart
+++ b/klubradio_archivum/lib/screens/home_screen/subscribed_podcasts_list.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+import '../../models/podcast.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+
+class SubscribedPodcastsList extends StatelessWidget {
+  const SubscribedPodcastsList({super.key, required this.podcasts});
+
+  final List<Podcast> podcasts;
+
+  @override
+  Widget build(BuildContext context) {
+    if (podcasts.isEmpty) {
+      return Text(
+        'Még nem iratkoztál fel egy műsorra sem.',
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+
+    return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: podcasts.length,
+      itemBuilder: (BuildContext context, int index) {
+        final Podcast podcast = podcasts[index];
+        return PodcastListItem(podcast: podcast);
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/now_playing_screen/audio_player_controls.dart
+++ b/klubradio_archivum/lib/screens/now_playing_screen/audio_player_controls.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../../providers/episode.provider.dart';
+import '../utils/constants.dart' as constants;
+
+class AudioPlayerControls extends StatelessWidget {
+  const AudioPlayerControls({super.key, required this.provider});
+
+  final EpisodeProvider provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool hasPrevious = provider.getPreviousEpisode() != null;
+    final bool hasNext = provider.getNextEpisode() != null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: <Widget>[
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            IconButton(
+              iconSize: 36,
+              icon: const Icon(Icons.skip_previous),
+              onPressed: hasPrevious
+                  ? () {
+                      provider.playPrevious();
+                    }
+                  : null,
+            ),
+            IconButton(
+              iconSize: 48,
+              icon: Icon(
+                provider.isPlaying ? Icons.pause_circle : Icons.play_circle,
+              ),
+              onPressed: () {
+                provider.togglePlayPause();
+              },
+            ),
+            IconButton(
+              iconSize: 36,
+              icon: const Icon(Icons.skip_next),
+              onPressed: hasNext
+                  ? () {
+                      provider.playNext();
+                    }
+                  : null,
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        DropdownButton<double>(
+          value: provider.playbackSpeed,
+          onChanged: (double? value) {
+            if (value != null) {
+              provider.updatePlaybackSpeed(value);
+            }
+          },
+          items: constants.playbackSpeeds.map((double speed) {
+            return DropdownMenuItem<double>(
+              value: speed,
+              child: Text('${speed}x'),
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/now_playing_screen/now_playing_screen.dart
+++ b/klubradio_archivum/lib/screens/now_playing_screen/now_playing_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode.provider.dart';
+import '../utils/helpers.dart';
+import 'audio_player_controls.dart';
+import 'progress_slider.dart';
+
+class NowPlayingScreen extends StatelessWidget {
+  const NowPlayingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (BuildContext context, EpisodeProvider provider, Widget? child) {
+        final episode = provider.currentEpisode;
+        if (episode == null) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Most szól')),
+            body: const Center(
+              child: Text('Jelenleg nincs lejátszott epizód.'),
+            ),
+          );
+        }
+
+        return Scaffold(
+          appBar: AppBar(title: const Text('Most szól')),
+          body: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  episode.title,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  formatDate(episode.publishedAt),
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  episode.description,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const Spacer(),
+                ProgressSlider(provider: provider),
+                const SizedBox(height: 24),
+                AudioPlayerControls(provider: provider),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/now_playing_screen/progress_slider.dart
+++ b/klubradio_archivum/lib/screens/now_playing_screen/progress_slider.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../../providers/episode.provider.dart';
+import '../utils/helpers.dart';
+
+class ProgressSlider extends StatelessWidget {
+  const ProgressSlider({super.key, required this.provider});
+
+  final EpisodeProvider provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final Duration position = provider.currentPosition;
+    final Duration total = provider.totalDuration ?? Duration.zero;
+    final double maxSeconds = total.inSeconds > 0 ? total.inSeconds.toDouble() : 1;
+    final double value = position.inSeconds.clamp(0, total.inSeconds).toDouble();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Slider(
+          value: value,
+          max: maxSeconds,
+          onChanged: (double newValue) {
+            provider.seek(Duration(seconds: newValue.toInt()));
+          },
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: <Widget>[
+            Text(formatDuration(position)),
+            Text(formatDuration(total)),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_detail_screen.dart
+++ b/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_detail_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/episode.dart';
+import '../../models/podcast.dart';
+import '../../providers/podcast_provider.dart';
+import '../widgets/stateful/episode_list.dart';
+import 'podcast_info_card.dart';
+
+class PodcastDetailScreen extends StatefulWidget {
+  const PodcastDetailScreen({super.key, required this.podcast});
+
+  final Podcast podcast;
+
+  @override
+  State<PodcastDetailScreen> createState() => _PodcastDetailScreenState();
+}
+
+class _PodcastDetailScreenState extends State<PodcastDetailScreen> {
+  late Future<void> _loadingFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadingFuture = _loadEpisodes();
+  }
+
+  Future<void> _loadEpisodes() async {
+    final PodcastProvider provider = context.read<PodcastProvider>();
+    await provider.fetchEpisodesForPodcast(widget.podcast.id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.podcast.title)),
+      body: FutureBuilder<void>(
+        future: _loadingFuture,
+        builder: (BuildContext context, AsyncSnapshot<void> snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text('Hiba történt: ${snapshot.error}'),
+              ),
+            );
+          }
+
+          final PodcastProvider provider = context.watch<PodcastProvider>();
+          final Future<List<Episode>> episodes =
+              provider.fetchEpisodesForPodcast(widget.podcast.id);
+
+          return FutureBuilder<List<Episode>>(
+            future: episodes,
+            builder:
+                (BuildContext context, AsyncSnapshot<List<Episode>> snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final List<Episode> episodeList = snapshot.data ?? const <Episode>[];
+              return ListView(
+                padding: const EdgeInsets.all(16),
+                children: <Widget>[
+                  PodcastInfoCard(podcast: widget.podcast),
+                  const SizedBox(height: 24),
+                  EpisodeList(episodes: List<Episode>.from(episodeList)),
+                  const SizedBox(height: 24),
+                  FilledButton(
+                    onPressed: () {
+                      provider.subscribe(widget.podcast.id);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Feliratkozás sikeres!')),
+                      );
+                    },
+                    child: const Text('Feliratkozás'),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_info_card.dart
+++ b/klubradio_archivum/lib/screens/podcast_detail_screen/podcast_info_card.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+import '../../models/podcast.dart';
+
+class PodcastInfoCard extends StatelessWidget {
+  const PodcastInfoCard({super.key, required this.podcast});
+
+  final Podcast podcast;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: podcast.coverImageUrl.isEmpty
+                      ? Container(
+                          width: 100,
+                          height: 100,
+                          color: theme.colorScheme.primaryContainer,
+                          child: const Icon(Icons.radio, size: 48),
+                        )
+                      : Image.network(
+                          podcast.coverImageUrl,
+                          width: 100,
+                          height: 100,
+                          fit: BoxFit.cover,
+                        ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        podcast.title,
+                        style: theme.textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        podcast.description,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      if (podcast.hosts.isNotEmpty)
+                        Text(
+                          'Műsorvezetők: ${podcast.hosts.map((host) => host.name).join(', ')}',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: podcast.categories
+                  .map((String category) => Chip(label: Text(category)))
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/profile_screen/profile_screen.dart
+++ b/klubradio_archivum/lib/screens/profile_screen/profile_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/podcast_provider.dart';
+import '../widgets/stateful/episode_list.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PodcastProvider>(
+      builder: (
+        BuildContext context,
+        PodcastProvider provider,
+        Widget? child,
+      ) {
+        final profile = provider.userProfile;
+        if (profile == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: <Widget>[
+            ListTile(
+              leading: CircleAvatar(
+                radius: 32,
+                backgroundImage:
+                    profile.avatarUrl != null ? NetworkImage(profile.avatarUrl!) : null,
+                child: profile.avatarUrl == null
+                    ? const Icon(Icons.person)
+                    : null,
+              ),
+              title: Text(profile.displayName),
+              subtitle: Text(profile.email ?? 'Nincs megadva e-mail cím'),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Letöltési beállítások',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            ListTile(
+              leading: const Icon(Icons.download_for_offline_outlined),
+              title: const Text('Automatikus letöltések'),
+              subtitle: Text('Epizódok száma: ${profile.maxAutoDownload}'),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Legutóbb hallgatott epizódok',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            EpisodeList(episodes: profile.recentlyPlayed, enableDownloads: false),
+            const SizedBox(height: 16),
+            Text(
+              'Kedvencek',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            if (profile.favouriteEpisodeIds.isEmpty)
+              Text(
+                'Nincsenek kedvenc epizódok.',
+                style: Theme.of(context).textTheme.bodyMedium,
+              )
+            else
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: profile.favouriteEpisodeIds
+                    .map((String id) => Chip(label: Text(id)))
+                    .toList(),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/recent_searches.dart
+++ b/klubradio_archivum/lib/screens/search_screen/recent_searches.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class RecentSearches extends StatelessWidget {
+  const RecentSearches({
+    super.key,
+    required this.searches,
+    required this.onSelected,
+  });
+
+  final List<String> searches;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    if (searches.isEmpty) {
+      return Text(
+        'Még nincs keresési előzmény.',
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: searches.map((String term) {
+        return ActionChip(
+          label: Text(term),
+          onPressed: () => onSelected(term),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/search_bar.dart
+++ b/klubradio_archivum/lib/screens/search_screen/search_bar.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+class SearchBarWidget extends StatefulWidget {
+  const SearchBarWidget({super.key, required this.onSubmitted});
+
+  final ValueChanged<String> onSubmitted;
+
+  @override
+  State<SearchBarWidget> createState() => _SearchBarWidgetState();
+}
+
+class _SearchBarWidgetState extends State<SearchBarWidget> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: _controller,
+      decoration: InputDecoration(
+        prefixIcon: const Icon(Icons.search),
+        hintText: 'Műsorok, műsorvezetők, kulcsszavak...',
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(24),
+        ),
+        suffixIcon: _controller.text.isEmpty
+            ? null
+            : IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: () {
+                  _controller.clear();
+                  setState(() {});
+                },
+              ),
+      ),
+      textInputAction: TextInputAction.search,
+      onChanged: (_) => setState(() {}),
+      onSubmitted: widget.onSubmitted,
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/search_results_list.dart
+++ b/klubradio_archivum/lib/screens/search_screen/search_results_list.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+import '../../models/podcast.dart';
+import '../widgets/stateless/podcast_list_item.dart';
+
+class SearchResultsList extends StatelessWidget {
+  const SearchResultsList({super.key, required this.results});
+
+  final List<Podcast> results;
+
+  @override
+  Widget build(BuildContext context) {
+    if (results.isEmpty) {
+      return Center(
+        child: Text(
+          'Nincs találat a megadott keresésre.',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+      );
+    }
+
+    return ListView.separated(
+      itemCount: results.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (BuildContext context, int index) {
+        final Podcast podcast = results[index];
+        return PodcastListItem(podcast: podcast);
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/search_screen/search_screen.dart
+++ b/klubradio_archivum/lib/screens/search_screen/search_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/podcast.dart';
+import '../../providers/podcast_provider.dart';
+import 'recent_searches.dart';
+import 'search_bar.dart';
+import 'search_results_list.dart';
+
+class SearchScreen extends StatefulWidget {
+  const SearchScreen({super.key});
+
+  @override
+  State<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends State<SearchScreen> {
+  Future<List<Podcast>>? _searchFuture;
+
+  void _onSearch(String query) {
+    final PodcastProvider provider = context.read<PodcastProvider>();
+    setState(() {
+      _searchFuture = provider.searchPodcasts(query);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final PodcastProvider provider = context.watch<PodcastProvider>();
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          SearchBarWidget(onSubmitted: _onSearch),
+          const SizedBox(height: 16),
+          RecentSearches(
+            searches: provider.recentSearches,
+            onSelected: _onSearch,
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: _searchFuture == null
+                ? Center(
+                    child: Text(
+                      'Keresd meg kedvenc műsoraidat vagy műsorvezetőidet.',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                : FutureBuilder<List<Podcast>>(
+                    future: _searchFuture,
+                    builder: (
+                      BuildContext context,
+                      AsyncSnapshot<List<Podcast>> snapshot,
+                    ) {
+                      if (snapshot.connectionState ==
+                          ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+                      if (snapshot.hasError) {
+                        return Center(
+                          child: Text('Hiba történt: ${snapshot.error}'),
+                        );
+                      }
+                      final List<Podcast> results =
+                          snapshot.data ?? const <Podcast>[];
+                      return SearchResultsList(results: results);
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/settings_screen/playback_settings.dart
+++ b/klubradio_archivum/lib/screens/settings_screen/playback_settings.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/episode.provider.dart';
+import '../../providers/podcast_provider.dart';
+import '../utils/constants.dart' as constants;
+
+class PlaybackSettings extends StatelessWidget {
+  const PlaybackSettings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Lejátszási beállítások',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Consumer<EpisodeProvider>(
+              builder: (
+                BuildContext context,
+                EpisodeProvider provider,
+                Widget? child,
+              ) {
+                return Row(
+                  children: <Widget>[
+                    const Text('Lejátszási sebesség:'),
+                    const SizedBox(width: 12),
+                    DropdownButton<double>(
+                      value: provider.playbackSpeed,
+                      items: constants.playbackSpeeds.map((double speed) {
+                        return DropdownMenuItem<double>(
+                          value: speed,
+                          child: Text('${speed}x'),
+                        );
+                      }).toList(),
+                      onChanged: (double? value) {
+                        if (value != null) {
+                          provider.updatePlaybackSpeed(value);
+                        }
+                      },
+                    ),
+                  ],
+                );
+              },
+            ),
+            const SizedBox(height: 12),
+            Consumer<PodcastProvider>(
+              builder: (
+                BuildContext context,
+                PodcastProvider provider,
+                Widget? child,
+              ) {
+                final autoDownload =
+                    provider.userProfile?.maxAutoDownload ??
+                        constants.defaultAutoDownloadCount;
+                return Row(
+                  children: <Widget>[
+                    const Text('Automatikus letöltések:'),
+                    const SizedBox(width: 12),
+                    DropdownButton<int>(
+                      value: autoDownload,
+                      items: constants.autoDownloadOptions.map((int count) {
+                        return DropdownMenuItem<int>(
+                          value: count,
+                          child: Text('$count epizód'),
+                        );
+                      }).toList(),
+                      onChanged: (int? value) {
+                        if (value != null) {
+                          provider.updateAutoDownloadCount(value);
+                        }
+                      },
+                    ),
+                  ],
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/settings_screen/settings_screen.dart
+++ b/klubradio_archivum/lib/screens/settings_screen/settings_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'playback_settings.dart';
+import 'theme_settings.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: <Widget>[
+        const ThemeSettings(),
+        const SizedBox(height: 16),
+        const PlaybackSettings(),
+        const SizedBox(height: 16),
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.favorite_outline),
+            title: const Text('Támogasd a Klubrádiót'),
+            subtitle: const Text('Nyisd meg a támogatási oldalt a böngészőben.'),
+            onTap: () {
+              launchUrl(
+                Uri.parse('https://www.klubradio.hu/tamogatas'),
+                mode: LaunchMode.externalApplication,
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: 16),
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.coffee),
+            title: const Text('Támogasd az alkalmazás fejlesztőjét'),
+            subtitle: const Text('Önkéntes adomány a további fejlesztésekhez.'),
+            onTap: () {
+              // TODO: Replace with a real donation URL.
+              launchUrl(
+                Uri.parse('https://ko-fi.com/your-page'),
+                mode: LaunchMode.externalApplication,
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/settings_screen/theme_settings.dart
+++ b/klubradio_archivum/lib/screens/settings_screen/theme_settings.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/theme_provider.dart';
+
+class ThemeSettings extends StatelessWidget {
+  const ThemeSettings({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Consumer<ThemeProvider>(
+          builder: (
+            BuildContext context,
+            ThemeProvider provider,
+            Widget? child,
+          ) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Téma beállítások',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Rendszerbeállítás'),
+                  value: ThemeMode.system,
+                  groupValue: provider.themeMode,
+                  onChanged: (ThemeMode? value) {
+                    if (value != null) {
+                      provider.setThemeMode(value);
+                    }
+                  },
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Világos mód'),
+                  value: ThemeMode.light,
+                  groupValue: provider.themeMode,
+                  onChanged: (ThemeMode? value) {
+                    if (value != null) {
+                      provider.setThemeMode(value);
+                    }
+                  },
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Sötét mód'),
+                  value: ThemeMode.dark,
+                  groupValue: provider.themeMode,
+                  onChanged: (ThemeMode? value) {
+                    if (value != null) {
+                      provider.setThemeMode(value);
+                    }
+                  },
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/utils/constants.dart
+++ b/klubradio_archivum/lib/screens/utils/constants.dart
@@ -1,0 +1,23 @@
+const String podcastsTable = 'podcasts';
+const String episodesTable = 'episodes';
+const String userProfilesTable = 'user_profiles';
+const String playbackEventsTable = 'playback_events';
+
+const int defaultAutoDownloadCount = 5;
+const int maxRecentSearches = 10;
+const int maxRecentlyPlayed = 20;
+
+const String demoUserId = 'guest-user';
+
+const List<String> topCategories = <String>[
+  'politika',
+  'közélet',
+  'gazdaság',
+  'kultúra',
+  'sport',
+  'tudomány',
+];
+
+const List<double> playbackSpeeds = <double>[0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
+
+const List<int> autoDownloadOptions = <int>[1, 3, 5, 7, 10];

--- a/klubradio_archivum/lib/screens/utils/helpers.dart
+++ b/klubradio_archivum/lib/screens/utils/helpers.dart
@@ -1,0 +1,39 @@
+import 'package:intl/intl.dart';
+
+import '../../models/episode.dart';
+
+String formatDate(DateTime dateTime, {String locale = 'hu'}) {
+  final DateFormat formatter = DateFormat.yMMMMEEEEd(locale).add_Hm();
+  return formatter.format(dateTime.toLocal());
+}
+
+String formatDuration(Duration duration) {
+  final int hours = duration.inHours;
+  final int minutes = duration.inMinutes.remainder(60);
+  final int seconds = duration.inSeconds.remainder(60);
+  if (hours > 0) {
+    return '${hours.toString().padLeft(2, '0')}:${minutes.toString().padLeft(2, '0')}:'
+        '${seconds.toString().padLeft(2, '0')}';
+  }
+  return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+}
+
+String formatDownloadStatus(DownloadStatus status) {
+  switch (status) {
+    case DownloadStatus.notDownloaded:
+      return 'Nincs letöltve';
+    case DownloadStatus.queued:
+      return 'Sorban';
+    case DownloadStatus.downloading:
+      return 'Letöltés alatt';
+    case DownloadStatus.downloaded:
+      return 'Kész';
+    case DownloadStatus.failed:
+      return 'Hiba történt';
+  }
+}
+
+String formatProgress(double progress) {
+  final int percentage = (progress * 100).clamp(0, 100).round();
+  return '$percentage%';
+}

--- a/klubradio_archivum/lib/screens/widgets/stateful/episode_list.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateful/episode_list.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../models/episode.dart';
+import '../../../providers/episode.provider.dart';
+import '../../../providers/podcast_provider.dart';
+import '../../../services/download_service.dart';
+import '../stateless/episode_list_item.dart';
+
+class EpisodeList extends StatefulWidget {
+  const EpisodeList({
+    super.key,
+    required this.episodes,
+    this.enableDownloads = true,
+  });
+
+  final List<Episode> episodes;
+  final bool enableDownloads;
+
+  @override
+  State<EpisodeList> createState() => _EpisodeListState();
+}
+
+class _EpisodeListState extends State<EpisodeList> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer2<EpisodeProvider, PodcastProvider>(
+      builder: (
+        BuildContext context,
+        EpisodeProvider episodeProvider,
+        PodcastProvider podcastProvider,
+        Widget? child,
+      ) {
+        return ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: widget.episodes.length,
+          itemBuilder: (BuildContext context, int index) {
+            final Episode episode = widget.episodes[index];
+            final DownloadTask? task =
+                podcastProvider.getDownloadTask(episode.id);
+            final DownloadStatus status =
+                task?.status ?? episode.downloadStatus;
+
+            return EpisodeListItem(
+              episode: episode,
+              onTap: () async {
+                await episodeProvider.playEpisode(
+                  episode,
+                  queue: widget.episodes,
+                );
+                podcastProvider.addRecentlyPlayed(episode);
+              },
+              trailing: widget.enableDownloads
+                  ? _DownloadButton(status: status, episode: episode)
+                  : null,
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _DownloadButton extends StatelessWidget {
+  const _DownloadButton({required this.status, required this.episode});
+
+  final DownloadStatus status;
+  final Episode episode;
+
+  @override
+  Widget build(BuildContext context) {
+    final PodcastProvider provider = context.read<PodcastProvider>();
+
+    switch (status) {
+      case DownloadStatus.downloading:
+        return const SizedBox(
+          width: 24,
+          height: 24,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        );
+      case DownloadStatus.downloaded:
+        return IconButton(
+          icon: const Icon(Icons.check_circle_outline),
+          onPressed: () {
+            // TODO: Open the downloaded file via local player integration.
+          },
+        );
+      case DownloadStatus.failed:
+        return IconButton(
+          icon: const Icon(Icons.refresh),
+          onPressed: () {
+            provider.downloadEpisode(episode);
+          },
+        );
+      case DownloadStatus.notDownloaded:
+      case DownloadStatus.queued:
+        return IconButton(
+          icon: const Icon(Icons.download_for_offline_outlined),
+          onPressed: () {
+            provider.downloadEpisode(episode);
+          },
+        );
+    }
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateful/now_playing_bar.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateful/now_playing_bar.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../providers/episode.provider.dart';
+import '../../now_playing_screen/now_playing_screen.dart';
+import '../../utils/helpers.dart';
+
+class NowPlayingBar extends StatelessWidget {
+  const NowPlayingBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<EpisodeProvider>(
+      builder: (
+        BuildContext context,
+        EpisodeProvider provider,
+        Widget? child,
+      ) {
+        final currentEpisode = provider.currentEpisode;
+        final Duration? total = provider.totalDuration;
+        final Duration position = provider.currentPosition;
+        final double progress =
+            total == null || total.inMilliseconds == 0
+                ? 0
+                : position.inMilliseconds / total.inMilliseconds;
+
+        if (currentEpisode == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Material(
+          color: Theme.of(context).colorScheme.surface,
+          elevation: 4,
+          child: InkWell(
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (BuildContext context) => const NowPlayingScreen(),
+                ),
+              );
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      IconButton(
+                        icon: Icon(
+                          provider.isPlaying
+                              ? Icons.pause_circle
+                              : Icons.play_circle,
+                          size: 32,
+                        ),
+                        onPressed: () {
+                          provider.togglePlayPause();
+                        },
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Text(
+                              currentEpisode.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            Text(
+                              formatDuration(position),
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.queue_music),
+                        onPressed: () {
+                          showModalBottomSheet<void>(
+                            context: context,
+                            builder: (BuildContext context) {
+                              return _QueueSheet(provider: provider);
+                            },
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  LinearProgressIndicator(value: progress.clamp(0, 1)),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _QueueSheet extends StatelessWidget {
+  const _QueueSheet({required this.provider});
+
+  final EpisodeProvider provider;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: provider.queue.length,
+      itemBuilder: (BuildContext context, int index) {
+        final episode = provider.queue[index];
+        final bool isCurrent = provider.currentEpisode?.id == episode.id;
+        return ListTile(
+          leading: Icon(isCurrent ? Icons.play_arrow : Icons.queue_music),
+          title: Text(episode.title),
+          subtitle: Text(formatDuration(episode.duration)),
+          onTap: () async {
+            Navigator.of(context).pop();
+            await provider.playEpisode(episode, queue: provider.queue);
+          },
+        );
+      },
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateless/bottom_navigation_bar.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateless/bottom_navigation_bar.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class AppBottomNavigationBar extends StatelessWidget {
+  const AppBottomNavigationBar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: currentIndex,
+      onDestinationSelected: onTap,
+      destinations: const <NavigationDestination>[
+        NavigationDestination(
+          icon: Icon(Icons.home_outlined),
+          selectedIcon: Icon(Icons.home),
+          label: 'Főoldal',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.explore_outlined),
+          selectedIcon: Icon(Icons.explore),
+          label: 'Felfedezés',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.search_outlined),
+          selectedIcon: Icon(Icons.search),
+          label: 'Keresés',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.download_outlined),
+          selectedIcon: Icon(Icons.download),
+          label: 'Letöltések',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.person_outline),
+          selectedIcon: Icon(Icons.person),
+          label: 'Profil',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.settings_outlined),
+          selectedIcon: Icon(Icons.settings),
+          label: 'Beállítások',
+        ),
+      ],
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateless/episode_list_item.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateless/episode_list_item.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/episode.dart';
+import '../../utils/helpers.dart';
+
+class EpisodeListItem extends StatelessWidget {
+  const EpisodeListItem({
+    super.key,
+    required this.episode,
+    this.onTap,
+    this.trailing,
+  });
+
+  final Episode episode;
+  final VoidCallback? onTap;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        leading: const Icon(Icons.podcasts_outlined),
+        title: Text(
+          episode.title,
+          style: theme.textTheme.titleMedium,
+        ),
+        subtitle: Text(
+          '${formatDate(episode.publishedAt)} • ${formatDuration(episode.duration)}',
+        ),
+        onTap: onTap,
+        trailing: trailing,
+      ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/screens/widgets/stateless/podcast_list_item.dart
+++ b/klubradio_archivum/lib/screens/widgets/stateless/podcast_list_item.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../models/podcast.dart';
+import '../../../providers/podcast_provider.dart';
+import '../../podcast_detail_screen/podcast_detail_screen.dart';
+
+class PodcastListItem extends StatelessWidget {
+  const PodcastListItem({
+    super.key,
+    required this.podcast,
+    this.showSubscribeButton = true,
+  });
+
+  final Podcast podcast;
+  final bool showSubscribeButton;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final PodcastProvider provider = context.watch<PodcastProvider>();
+    final bool isSubscribed = provider.userProfile?.subscribedPodcastIds
+            .contains(podcast.id) ??
+        podcast.isSubscribed;
+    final String subtitle = podcast.hosts.isNotEmpty
+        ? podcast.hosts.map((host) => host.name).join(', ')
+        : 'Klubrádió műsor';
+
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute<void>(
+              builder: (BuildContext context) => PodcastDetailScreen(
+                podcast: podcast,
+              ),
+            ),
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              _CoverArt(imageUrl: podcast.coverImageUrl),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      podcast.title,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      podcast.description,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall,
+                    ),
+                    if (showSubscribeButton)
+                      Align(
+                        alignment: Alignment.centerLeft,
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 12),
+                          child: OutlinedButton.icon(
+                            icon: Icon(
+                              isSubscribed
+                                  ? Icons.notifications_active
+                                  : Icons.notifications_outlined,
+                            ),
+                            label: Text(
+                              isSubscribed ? 'Feliratkozva' : 'Feliratkozás',
+                            ),
+                            onPressed: () {
+                              if (isSubscribed) {
+                                provider.unsubscribe(podcast.id);
+                              } else {
+                                provider.subscribe(podcast.id);
+                              }
+                            },
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CoverArt extends StatelessWidget {
+  const _CoverArt({required this.imageUrl});
+
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: imageUrl.isEmpty
+          ? Container(
+              width: 72,
+              height: 72,
+              color: Theme.of(context).colorScheme.primaryContainer,
+              child: const Icon(Icons.radio),
+            )
+          : Image.network(
+              imageUrl,
+              width: 72,
+              height: 72,
+              fit: BoxFit.cover,
+              errorBuilder:
+                  (BuildContext context, Object error, StackTrace? stackTrace) {
+                return Container(
+                  width: 72,
+                  height: 72,
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  child: const Icon(Icons.radio),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/klubradio_archivum/lib/services/api_service.dart
+++ b/klubradio_archivum/lib/services/api_service.dart
@@ -1,0 +1,343 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/episode.dart';
+import '../models/podcast.dart';
+import '../models/show_host.dart';
+import '../models/user_profile.dart';
+import '../screens/utils/constants.dart' as constants;
+
+class ApiService {
+  ApiService({http.Client? httpClient}) : _httpClient = httpClient ?? http.Client();
+
+  static const String _supabaseUrl = 'https://TODO.supabase.co';
+  // TODO: Replace with your Supabase project URL above.
+  static const String _supabaseKey = 'TODO: Supabase anon key';
+  // TODO: Replace with your Supabase public anon API key above.
+  static const Duration _timeout = Duration(seconds: 20);
+
+  final http.Client _httpClient;
+
+  bool get hasValidCredentials =>
+      !_supabaseUrl.contains('TODO') && !_supabaseKey.contains('TODO');
+
+  Map<String, String> get _headers => <String, String>{
+        'apikey': _supabaseKey,
+        'Authorization': 'Bearer $_supabaseKey',
+        'Content-Type': 'application/json',
+      };
+
+  Future<List<Podcast>> fetchLatestPodcasts({int limit = 20}) async {
+    if (!hasValidCredentials) {
+      return _mockPodcasts();
+    }
+
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.podcastsTable}'
+      '?select=*,hosts(*),latestEpisode:episodes(*)'
+      '&order=lastUpdated.desc'
+      '&limit=$limit',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(Podcast.fromJson)
+          .toList();
+    }
+
+    throw ApiException('Unable to fetch podcasts (${response.statusCode})');
+  }
+
+  Future<List<Podcast>> fetchTrendingPodcasts({int limit = 10}) async {
+    if (!hasValidCredentials) {
+      return _mockPodcasts().take(limit).map((Podcast podcast) {
+        return podcast.copyWith(isTrending: true);
+      }).toList();
+    }
+
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.podcastsTable}'
+      '?select=*,hosts(*)'
+      '&order=playCount.desc.nullslast'
+      '&limit=$limit',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(Podcast.fromJson)
+          .map((Podcast podcast) => podcast.copyWith(isTrending: true))
+          .toList();
+    }
+
+    throw ApiException('Unable to fetch trending podcasts');
+  }
+
+  Future<List<Podcast>> fetchRecommendedPodcasts({int limit = 10}) async {
+    if (!hasValidCredentials) {
+      return _mockPodcasts().take(limit).map((Podcast podcast) {
+        return podcast.copyWith(isRecommended: true);
+      }).toList();
+    }
+
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.podcastsTable}'
+      '?select=*,hosts(*)'
+      '&order=recommendationScore.desc.nullslast'
+      '&limit=$limit',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      return data
+          .whereType<Map<String, dynamic>>()
+          .map(Podcast.fromJson)
+          .map((Podcast podcast) => podcast.copyWith(isRecommended: true))
+          .toList();
+    }
+
+    throw ApiException('Unable to fetch recommended podcasts');
+  }
+
+  Future<List<Episode>> fetchEpisodesForPodcast(
+    String podcastId, {
+    int limit = 50,
+  }) async {
+    if (!hasValidCredentials) {
+      return _mockEpisodes(podcastId).take(limit).toList();
+    }
+
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.episodesTable}'
+      '?select=*'
+      '&podcastId=eq.$podcastId'
+      '&order=publishedAt.desc'
+      '&limit=$limit',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      return data.whereType<Map<String, dynamic>>().map(Episode.fromJson).toList();
+    }
+
+    throw ApiException('Unable to fetch episodes for podcast $podcastId');
+  }
+
+  Future<List<Episode>> fetchRecentEpisodes({int limit = 20}) async {
+    if (!hasValidCredentials) {
+      final List<Episode> mocked = _mockPodcasts()
+          .expand((Podcast podcast) => _mockEpisodes(podcast.id))
+          .toList()
+        ..sort((Episode a, Episode b) =>
+            b.publishedAt.compareTo(a.publishedAt));
+      return mocked.take(limit).toList();
+    }
+
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.episodesTable}'
+      '?select=*'
+      '&order=publishedAt.desc'
+      '&limit=$limit',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      return data.whereType<Map<String, dynamic>>().map(Episode.fromJson).toList();
+    }
+
+    throw ApiException('Unable to fetch recent episodes');
+  }
+
+  Future<List<Podcast>> searchPodcasts(String query) async {
+    if (query.trim().isEmpty) {
+      return const <Podcast>[];
+    }
+
+    if (!hasValidCredentials) {
+      return _mockPodcasts()
+          .where((Podcast podcast) =>
+              podcast.title.toLowerCase().contains(query.toLowerCase()))
+          .toList();
+    }
+
+    final encodedQuery = query.replaceAll("'", "''");
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.podcastsTable}'
+      '?select=*,hosts(*)'
+      '&title=ilike.%25$encodedQuery%25',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      return data.whereType<Map<String, dynamic>>().map(Podcast.fromJson).toList();
+    }
+
+    throw ApiException('Unable to search podcasts');
+  }
+
+  Future<UserProfile> fetchUserProfile(String userId) async {
+    if (!hasValidCredentials) {
+      final List<Podcast> podcasts = _mockPodcasts();
+      final List<Episode> episodes = podcasts
+          .expand((Podcast podcast) => _mockEpisodes(podcast.id))
+          .toList();
+      return UserProfile(
+        id: userId,
+        displayName: 'Vendég felhasználó',
+        subscribedPodcastIds: podcasts.take(2).map((Podcast p) => p.id).toSet(),
+        recentlyPlayed: episodes.take(4).toList(),
+        favouriteEpisodeIds: episodes.take(3).map((Episode e) => e.id).toSet(),
+      );
+    }
+
+    final Uri uri = Uri.parse(
+      '$_supabaseUrl/rest/v1/${constants.userProfilesTable}'
+      '?select=*'
+      '&id=eq.$userId'
+      '&limit=1',
+    );
+    final http.Response response =
+        await _httpClient.get(uri, headers: _headers).timeout(_timeout);
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      final List<dynamic> data = jsonDecode(response.body) as List<dynamic>;
+      if (data.isEmpty) {
+        throw ApiException('Profile not found for $userId');
+      }
+      return UserProfile.fromJson(data.first as Map<String, dynamic>);
+    }
+
+    throw ApiException('Unable to fetch user profile ($userId)');
+  }
+
+  Future<void> logPlayback({required String episodeId}) async {
+    if (!hasValidCredentials) {
+      return;
+    }
+
+    final Uri uri =
+        Uri.parse('$_supabaseUrl/rest/v1/${constants.playbackEventsTable}');
+    final http.Response response = await _httpClient
+        .post(
+          uri,
+          headers: _headers,
+          body: jsonEncode(<String, dynamic>{
+            'episodeId': episodeId,
+            'playedAt': DateTime.now().toIso8601String(),
+          }),
+        )
+        .timeout(_timeout);
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ApiException('Unable to log playback event');
+    }
+  }
+
+  void dispose() {
+    _httpClient.close();
+  }
+
+  List<Podcast> _mockPodcasts() {
+    final ShowHost bolgarGyorgy = ShowHost(
+      id: '1',
+      name: 'Bolgár György',
+      bio:
+          'Ikonikus újságíró és műsorvezető, a Klubrádió egyik legismertebb hangja.',
+    );
+    final ShowHost szenteVeronika = ShowHost(
+      id: '2',
+      name: 'Szente Veronika',
+      bio: 'Kultúra és közélet szakértő.',
+    );
+
+    final List<Podcast> podcasts = <Podcast>[
+      Podcast(
+        id: 'esti-gyors',
+        title: 'Esti gyors',
+        description:
+            'Az Esti gyors napi közéleti összefoglalója a legfontosabb hírekkel.',
+        categories: const <String>['politika', 'közélet'],
+        coverImageUrl:
+            'https://images.klubradio.hu/podcasts/esti-gyors.jpg',
+        language: 'hu',
+        episodeCount: 1200,
+        hosts: <ShowHost>[bolgarGyorgy],
+        latestEpisode: _mockEpisodes('esti-gyors').first,
+        lastUpdated: DateTime.now(),
+        isTrending: true,
+      ),
+      Podcast(
+        id: 'megbeszeljuk',
+        title: 'Megbeszéljük',
+        description:
+            'Bolgár György legendás betelefonálós műsora a hallgatók kérdéseivel.',
+        categories: const <String>['politika', 'vélemény'],
+        coverImageUrl:
+            'https://images.klubradio.hu/podcasts/megbeszeljuk.jpg',
+        language: 'hu',
+        episodeCount: 1800,
+        hosts: <ShowHost>[bolgarGyorgy],
+        latestEpisode: _mockEpisodes('megbeszeljuk').first,
+        lastUpdated: DateTime.now().subtract(const Duration(hours: 3)),
+        isRecommended: true,
+      ),
+      Podcast(
+        id: 'hangos-irodalom',
+        title: 'Hangos irodalom',
+        description:
+            'Kulturális műsor irodalmi érdekességekkel és felolvasásokkal.',
+        categories: const <String>['kultúra'],
+        coverImageUrl:
+            'https://images.klubradio.hu/podcasts/hangos-irodalom.jpg',
+        language: 'hu',
+        episodeCount: 540,
+        hosts: <ShowHost>[szenteVeronika],
+        latestEpisode: _mockEpisodes('hangos-irodalom').first,
+        lastUpdated: DateTime.now().subtract(const Duration(days: 1)),
+      ),
+    ];
+
+    return podcasts;
+  }
+
+  Iterable<Episode> _mockEpisodes(String podcastId) sync* {
+    for (int index = 0; index < 12; index++) {
+      yield Episode(
+        id: '$podcastId-ep-$index',
+        podcastId: podcastId,
+        title: 'Epizód #$index',
+        description:
+            'Ez egy mintapélda epizód leírása a(z) $podcastId műsorhoz.',
+        audioUrl: 'https://cdn.klubradio.hu/audio/$podcastId/$index.mp3',
+        publishedAt: DateTime.now().subtract(Duration(days: index)),
+        duration: Duration(minutes: 55 - index.clamp(0, 20)),
+        hosts: const <String>['Klubrádió stáb'],
+      );
+    }
+  }
+}
+
+class ApiException implements Exception {
+  ApiException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'ApiException: $message';
+}

--- a/klubradio_archivum/lib/services/audio_player_service.dart
+++ b/klubradio_archivum/lib/services/audio_player_service.dart
@@ -1,0 +1,67 @@
+import 'dart:async';
+
+import 'package:just_audio/just_audio.dart';
+
+import '../models/episode.dart';
+
+class AudioPlayerService {
+  AudioPlayerService() {
+    _playerStateSubscription =
+        _player.playerStateStream.listen(_handlePlayerStateChange);
+  }
+
+  final AudioPlayer _player = AudioPlayer();
+  final StreamController<bool> _bufferingController =
+      StreamController<bool>.broadcast();
+
+  Episode? _currentEpisode;
+  StreamSubscription<PlayerState>? _playerStateSubscription;
+
+  Episode? get currentEpisode => _currentEpisode;
+  Stream<bool> get bufferingStream => _bufferingController.stream;
+  Stream<Duration> get positionStream => _player.positionStream;
+  Stream<Duration> get bufferedPositionStream => _player.bufferedPositionStream;
+  Stream<PlayerState> get playerStateStream => _player.playerStateStream;
+  bool get isPlaying => _player.playing;
+  Duration? get totalDuration => _player.duration;
+
+  Future<void> loadEpisode(Episode episode, {bool autoplay = true}) async {
+    _currentEpisode = episode;
+    try {
+      await _player.setUrl(episode.audioUrl);
+      if (autoplay) {
+        await _player.play();
+      }
+    } on PlayerException catch (error) {
+      _bufferingController.addError(error);
+    } on PlayerInterruptedException catch (error) {
+      _bufferingController.addError(error);
+    }
+  }
+
+  Future<void> togglePlayPause() async {
+    if (_player.playing) {
+      await _player.pause();
+    } else {
+      await _player.play();
+    }
+  }
+
+  Future<void> stop() => _player.stop();
+
+  Future<void> seek(Duration position) => _player.seek(position);
+
+  Future<void> setSpeed(double speed) => _player.setSpeed(speed);
+
+  Future<void> setVolume(double volume) => _player.setVolume(volume);
+
+  void _handlePlayerStateChange(PlayerState state) {
+    _bufferingController.add(state.processingState == ProcessingState.buffering);
+  }
+
+  Future<void> dispose() async {
+    await _playerStateSubscription?.cancel();
+    await _player.dispose();
+    await _bufferingController.close();
+  }
+}

--- a/klubradio_archivum/lib/services/download_service.dart
+++ b/klubradio_archivum/lib/services/download_service.dart
@@ -1,0 +1,131 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:path_provider/path_provider.dart';
+
+import '../models/episode.dart';
+
+class DownloadTask {
+  DownloadTask({
+    required this.episode,
+    this.progress = 0,
+    this.status = DownloadStatus.notDownloaded,
+    this.filePath,
+    this.error,
+  });
+
+  final Episode episode;
+  double progress;
+  DownloadStatus status;
+  String? filePath;
+  Object? error;
+
+  DownloadTask copyWith({
+    double? progress,
+    DownloadStatus? status,
+    String? filePath,
+    Object? error,
+  }) {
+    return DownloadTask(
+      episode: episode,
+      progress: progress ?? this.progress,
+      status: status ?? this.status,
+      filePath: filePath ?? this.filePath,
+      error: error ?? this.error,
+    );
+  }
+}
+
+class DownloadService {
+  DownloadService({http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client();
+
+  final http.Client _httpClient;
+  final Map<String, DownloadTask> _tasks = <String, DownloadTask>{};
+  final StreamController<DownloadTask> _downloadController =
+      StreamController<DownloadTask>.broadcast();
+
+  Stream<DownloadTask> get downloadStream => _downloadController.stream;
+  List<DownloadTask> get activeDownloads => _tasks.values.toList();
+
+  Future<DownloadTask> downloadEpisode(Episode episode) async {
+    final DownloadTask existing = _tasks[episode.id] ??
+        DownloadTask(episode: episode, status: DownloadStatus.queued);
+    _tasks[episode.id] = existing;
+    _downloadController.add(existing.copyWith());
+
+    final Directory directory = await _ensureDownloadDirectory();
+    final File file = File('${directory.path}/${episode.id}.mp3');
+    existing
+      ..filePath = file.path
+      ..status = DownloadStatus.downloading
+      ..progress = 0;
+    _downloadController.add(existing.copyWith());
+
+    try {
+      final http.Request request =
+          http.Request('GET', Uri.parse(episode.audioUrl));
+      final http.StreamedResponse response = await _httpClient.send(request);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw HttpException('Unexpected status ${response.statusCode}');
+      }
+
+      final IOSink sink = file.openWrite();
+      int received = 0;
+      final int? total = response.contentLength;
+
+      await for (final List<int> chunk in response.stream) {
+        received += chunk.length;
+        sink.add(chunk);
+        if (total != null && total > 0) {
+          existing.progress = received / total;
+          _downloadController.add(existing.copyWith());
+        }
+      }
+
+      await sink.close();
+      existing
+        ..status = DownloadStatus.downloaded
+        ..progress = 1;
+      _downloadController.add(existing.copyWith());
+    } catch (error) {
+      existing
+        ..status = DownloadStatus.failed
+        ..progress = 0
+        ..error = error;
+      _downloadController.add(existing.copyWith(error: error));
+      rethrow;
+    }
+
+    return existing;
+  }
+
+  Future<void> removeDownload(String episodeId) async {
+    final DownloadTask? task = _tasks.remove(episodeId);
+    if (task?.filePath != null) {
+      final File file = File(task!.filePath!);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    }
+    if (task != null) {
+      _downloadController.add(task.copyWith(status: DownloadStatus.notDownloaded));
+    }
+  }
+
+  Future<Directory> _ensureDownloadDirectory() async {
+    final Directory baseDirectory = await getApplicationDocumentsDirectory();
+    final Directory downloadDirectory =
+        Directory('${baseDirectory.path}/downloads');
+    if (!await downloadDirectory.exists()) {
+      await downloadDirectory.create(recursive: true);
+    }
+    return downloadDirectory;
+  }
+
+  Future<void> dispose() async {
+    await _downloadController.close();
+    _httpClient.close();
+  }
+}

--- a/klubradio_archivum/pubspec.yaml
+++ b/klubradio_archivum/pubspec.yaml
@@ -34,6 +34,17 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  http: ^1.2.2
+  html: ^0.15.5
+  xml: ^6.5.0
+  just_audio: ^0.9.39
+  provider: ^6.1.2
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  path_provider: ^2.1.3
+  url_launcher: ^6.3.0
+  shared_preferences: ^2.2.3
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace the template main.dart with a MultiProvider-based application shell wired to the new navigation and theming structure
- add data models, services, and providers to manage Supabase-backed content, audio playback, and download state (including TODO placeholders for credentials)
- implement screens, widgets, and utilities for browsing, searching, playing, and managing Klubrádió archive episodes
- extend pubspec dependencies to support HTTP access, audio playback, downloads, persistence, and UI helpers

## Testing
- flutter --version *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1bbcd82c832ba4a95c501eeaf181